### PR TITLE
dropping nfolds to 3 for H2O CV for large data

### DIFF
--- a/src/edvise/modeling/h2o_ml/training.py
+++ b/src/edvise/modeling/h2o_ml/training.py
@@ -144,6 +144,11 @@ def run_h2o_automl_classification(
 
     train, valid, test = h2o_splits["train"], h2o_splits["validate"], h2o_splits["test"]
 
+    n_rows = int(train.nrows)
+    nfolds = 5 if n_rows < 30_000 else 3
+
+    LOGGER.info("AutoML CV config: training_rows=%d, nfolds=%d", n_rows, nfolds)
+
     # Run H2O AutoML
     processed_model_features = [c for c in train.columns if c not in exclude_cols]
     LOGGER.info(f"Running H2O AutoML with {len(processed_model_features)} features...")
@@ -156,7 +161,7 @@ def run_h2o_automl_classification(
         seed=seed,
         verbosity="info",
         include_algos=frameworks,
-        nfolds=5,
+        nfolds=nfolds,
     )
 
     # Only pass weights_column if it exists in the data


### PR DESCRIPTION

When we have a ton of data, CV gets expensive in terms of taking up training time. So, limiting to 3 is necessary when you have more than 50,000 data points etc. The difference is like 80 models trained in 30 minutes vs. 200 models trained in 30 minutes.