### PR TITLE
Feature/log training config

### DIFF
--- a/pipelines/pdp/resources/github_pdp_inference.yml
+++ b/pipelines/pdp/resources/github_pdp_inference.yml
@@ -21,6 +21,8 @@ resources:
               - "{{job.parameters.DB_workspace}}"
               - --gcp_bucket_name
               - "{{job.parameters.gcp_bucket_name}}"
+              - --model_name
+              - "{{job.parameters.model_name}}"
           job_cluster_key: edvise-pdp-inference-pipeline-cluster
           libraries:
             - pypi:
@@ -40,12 +42,12 @@ resources:
               - "/Volumes/{{job.parameters.DB_workspace}}/{{job.parameters.databricks_institution_name}}_silver/silver_volume"
               - --DB_workspace
               - "{{job.parameters.DB_workspace}}"
-              - --config_file_path 
-              - "/Volumes/{{job.parameters.DB_workspace}}/{{job.parameters.databricks_institution_name}}_bronze/bronze_volume/training_inputs/{{job.parameters.config_file_name}}"
               - --job_type
               - "{{job.parameters.job_type}}"
               - --db_run_id
               - "{{job.parameters.db_run_id}}"
+              - --config_file_path
+              - "{{tasks.data_ingestion.values.config_file_path}}"
           job_cluster_key: edvise-pdp-inference-pipeline-cluster
           libraries:
             - pypi:
@@ -75,12 +77,12 @@ resources:
             parameters:
               - --silver_volume_path
               - "/Volumes/{{job.parameters.DB_workspace}}/{{job.parameters.databricks_institution_name}}_silver/silver_volume"
-              - --config_file_path 
-              - "/Volumes/{{job.parameters.DB_workspace}}/{{job.parameters.databricks_institution_name}}_bronze/bronze_volume/training_inputs/{{job.parameters.config_file_name}}"
               - --db_run_id
               - "{{job.parameters.db_run_id}}"
               - --job_type
               - "{{job.parameters.job_type}}"
+              - --config_file_path
+              - "{{tasks.data_ingestion.values.config_file_path}}"
           job_cluster_key: edvise-pdp-inference-pipeline-cluster
           libraries:
             - pypi:
@@ -110,12 +112,12 @@ resources:
             parameters:
               - --silver_volume_path
               - "/Volumes/{{job.parameters.DB_workspace}}/{{job.parameters.databricks_institution_name}}_silver/silver_volume"
-              - --config_file_path 
-              - "/Volumes/{{job.parameters.DB_workspace}}/{{job.parameters.databricks_institution_name}}_bronze/bronze_volume/training_inputs/{{job.parameters.config_file_name}}"
               - --db_run_id
               - "{{job.parameters.db_run_id}}"
               - --job_type
               - "{{job.parameters.job_type}}"
+              - --config_file_path
+              - "{{tasks.data_ingestion.values.config_file_path}}"              
           job_cluster_key: edvise-pdp-inference-pipeline-cluster
           libraries:
             - pypi:
@@ -145,12 +147,12 @@ resources:
             parameters:
               - --silver_volume_path
               - "/Volumes/{{job.parameters.DB_workspace}}/{{job.parameters.databricks_institution_name}}_silver/silver_volume"
-              - --config_file_path 
-              - "/Volumes/{{job.parameters.DB_workspace}}/{{job.parameters.databricks_institution_name}}_bronze/bronze_volume/training_inputs/{{job.parameters.config_file_name}}"
               - --db_run_id
               - "{{job.parameters.db_run_id}}"
               - --job_type
               - "{{job.parameters.job_type}}"
+              - --config_file_path
+              - "{{tasks.data_ingestion.values.config_file_path}}"              
           job_cluster_key: edvise-pdp-inference-pipeline-cluster
           libraries:
             - pypi:
@@ -181,10 +183,10 @@ resources:
             parameters:
               - --silver_volume_path
               - "/Volumes/{{job.parameters.DB_workspace}}/{{job.parameters.databricks_institution_name}}_silver/silver_volume"
-              - --config_file_path 
-              - "/Volumes/{{job.parameters.DB_workspace}}/{{job.parameters.databricks_institution_name}}_bronze/bronze_volume/training_inputs/{{job.parameters.config_file_name}}"
               - --db_run_id
               - "{{job.parameters.db_run_id}}"
+              - --config_file_path
+              - "{{tasks.data_ingestion.values.config_file_path}}"
           job_cluster_key: edvise-pdp-inference-pipeline-cluster
           libraries:
             - pypi:
@@ -224,8 +226,6 @@ resources:
               - "{{job.parameters.DB_workspace}}.{{job.parameters.databricks_institution_name}}_silver"
               - --silver_volume_path
               - "/Volumes/{{job.parameters.DB_workspace}}/{{job.parameters.databricks_institution_name}}_silver/silver_volume"
-              - --config_file_path 
-              - "/Volumes/{{job.parameters.DB_workspace}}/{{job.parameters.databricks_institution_name}}_bronze/bronze_volume/training_inputs/{{job.parameters.config_file_name}}"
               - --db_run_id
               - "{{job.parameters.db_run_id}}"
               - --ds_run_as
@@ -242,6 +242,8 @@ resources:
               - "{{job.parameters.DK_CC_EMAIL}}"
               - --job_root_dir  
               - "/Volumes/{{job.parameters.DB_workspace}}/{{job.parameters.databricks_institution_name}}_gold/gold_volume/inference_jobs/{{job.parameters.db_run_id}}"
+              - --config_file_path
+              - "{{tasks.data_ingestion.values.config_file_path}}"
           job_cluster_key: edvise-sklearn-inference-cluster
           libraries:
             - pypi:
@@ -292,8 +294,6 @@ resources:
             parameters:
               - --silver_volume_path
               - "/Volumes/{{job.parameters.DB_workspace}}/{{job.parameters.databricks_institution_name}}_silver/silver_volume"
-              - --config_file_path 
-              - "/Volumes/{{job.parameters.DB_workspace}}/{{job.parameters.databricks_institution_name}}_bronze/bronze_volume/training_inputs/{{job.parameters.config_file_name}}"
               - --db_run_id
               - "{{job.parameters.db_run_id}}"
               - --ds_run_as
@@ -308,6 +308,8 @@ resources:
               - "{{job.parameters.DK_CC_EMAIL}}"
               - --job_root_dir  
               - "/Volumes/{{job.parameters.DB_workspace}}/{{job.parameters.databricks_institution_name}}_gold/gold_volume/inference_jobs/{{job.parameters.db_run_id}}"
+              - --config_file_path
+              - "{{tasks.data_ingestion.values.config_file_path}}"
           job_cluster_key: edvise-pdp-inference-pipeline-cluster
           libraries:
             - pypi:
@@ -435,6 +437,8 @@ resources:
           default: sklearn
         - name: job_type
           default: inference
+        - name: model_name
+          default: flathead_valley_cc_retention_end_of_first_term
       permissions:
         - group_name: ${var.datakind_group_to_manage_workflow} 
           level: CAN_MANAGE

--- a/pipelines/pdp/resources/github_pdp_training.yml
+++ b/pipelines/pdp/resources/github_pdp_training.yml
@@ -237,14 +237,14 @@ resources:
               - "/Volumes/{{job.parameters.DB_workspace}}/{{job.parameters.databricks_institution_name}}_silver/silver_volume"
               - --config_file_path 
               - "/Volumes/{{job.parameters.DB_workspace}}/{{job.parameters.databricks_institution_name}}_bronze/bronze_volume/training_inputs/{{job.parameters.config_file_name}}"
+              - --config_file_name
+              - "{{job.parameters.config_file_name}}"
               - --db_run_id
               - "{{job.parameters.db_run_id}}"
               - --ds_run_as
               - "{{job.parameters.ds_run_as}}"
               - --DB_workspace
               - "{{job.parameters.DB_workspace}}"
-              - --config_file_name
-              - "{{job.parameters.config_file_name}}"
               - --gold_table_path
               - "{{job.parameters.DB_workspace}}.{{job.parameters.databricks_institution_name}}_gold"
           job_cluster_key: edvise-pdp-training-pipeline-cluster

--- a/src/edvise/scripts/pdp_gcp_databricks_ingestion.py
+++ b/src/edvise/scripts/pdp_gcp_databricks_ingestion.py
@@ -211,6 +211,7 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--gcp_bucket_name", required=True)
     parser.add_argument("--custom_schemas_path", required=False)
     parser.add_argument("--model_name", required=True)
+    # parser.add_argument("--config_file_path", required=False)
     
     return parser.parse_args()
 

--- a/src/edvise/scripts/pdp_gcp_databricks_ingestion.py
+++ b/src/edvise/scripts/pdp_gcp_databricks_ingestion.py
@@ -6,7 +6,6 @@ import typing as t
 import importlib
 import pandas as pd
 import pathlib
-import mlflow
 from mlflow.tracking import MlflowClient
 from google.cloud import storage
 from google.api_core.exceptions import Forbidden, NotFound

--- a/src/edvise/scripts/training_h2o.py
+++ b/src/edvise/scripts/training_h2o.py
@@ -443,10 +443,10 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--DB_workspace", type=str, required=True)
     parser.add_argument("--silver_volume_path", type=str, required=True)
     parser.add_argument("--config_file_path", type=str, required=True)
-    parser.add_argument("--config_file_name", type=str, required=True)
     parser.add_argument("--db_run_id", type=str, required=False)
     parser.add_argument("--ds_run_as", type=str, required=False)
     parser.add_argument("--gold_table_path", type=str, required=True)
+    parser.add_argument("--config_file_name", type=str, required=True)
     return parser.parse_args()
 
 

--- a/src/edvise/scripts/training_h2o.py
+++ b/src/edvise/scripts/training_h2o.py
@@ -420,7 +420,9 @@ class TrainingTask:
         self.evaluate_models(df_modeling, experiment_id)
 
         logging.info("Selecting best model")
-        self.select_model(experiment_id, [f"{current_run_path}/{self.args.config_file_name}"])
+        self.select_model(
+            experiment_id, [f"{current_run_path}/{self.args.config_file_name}"]
+        )
 
         logging.info("Generating training predictions & SHAP values")
         self.make_predictions(current_run_path=current_run_path)

--- a/src/edvise/scripts/training_h2o.py
+++ b/src/edvise/scripts/training_h2o.py
@@ -420,7 +420,7 @@ class TrainingTask:
         self.evaluate_models(df_modeling, experiment_id)
 
         logging.info("Selecting best model")
-        self.select_model(experiment_id, [f"{current_run_path}/{self.args.config_file_name}.toml"])
+        self.select_model(experiment_id, [f"{current_run_path}/{self.args.config_file_name}"])
 
         logging.info("Generating training predictions & SHAP values")
         self.make_predictions(current_run_path=current_run_path)

--- a/src/edvise/scripts/training_h2o.py
+++ b/src/edvise/scripts/training_h2o.py
@@ -265,7 +265,7 @@ class TrainingTask:
                 )
                 logging.info("Run %s: Completed", run_id)
 
-    def select_model(self, experiment_id: str) -> None:
+    def select_model(self, experiment_id: str, extra_save_paths: list[str]) -> None:
         topn = 5
         if (mc := self.cfg.modeling) is not None and (ev := mc.evaluation) is not None:
             topn = ev.topn_runs_included
@@ -288,6 +288,7 @@ class TrainingTask:
             config_path=self.args.config_file_path,
             run_id=top_run_id,
             experiment_id=experiment_id,
+            extra_save_paths=extra_save_paths,
         )
 
         # create parameter for updated config post model-selection
@@ -419,7 +420,7 @@ class TrainingTask:
         self.evaluate_models(df_modeling, experiment_id)
 
         logging.info("Selecting best model")
-        self.select_model(experiment_id)
+        self.select_model(experiment_id, [f"{current_run_path}/{self.args.config_file_name}.toml"])
 
         logging.info("Generating training predictions & SHAP values")
         self.make_predictions(current_run_path=current_run_path)

--- a/src/edvise/utils/update_config.py
+++ b/src/edvise/utils/update_config.py
@@ -88,11 +88,11 @@ class TomlConfigEditor:
 
 
 def update_run_metadata(
-        config_path: str, 
-        run_id: str, 
-        experiment_id: str, 
-        extra_save_paths: list[str] | None = None,
-        ) -> None:
+    config_path: str,
+    run_id: str,
+    experiment_id: str,
+    extra_save_paths: list[str] | None = None,
+) -> None:
     editor = TomlConfigEditor(config_path)
     editor.update_field(["model", "run_id"], run_id)
     editor.update_field(["model", "experiment_id"], experiment_id)
@@ -120,4 +120,3 @@ def update_key_courses_and_cips(
 
     # Save to the original config path
     editor.save()
-

--- a/src/edvise/utils/update_config.py
+++ b/src/edvise/utils/update_config.py
@@ -34,9 +34,14 @@ class TomlConfigEditor:
         current[key_path[-1]] = value
         LOGGER.debug("Set %s to %s", ".".join(key_path), value)
 
-    def save(self) -> None:
-        self.path.write_text(dumps(self._doc))
-        LOGGER.info("Saved updated TOML to %s", self.path)
+    # def save(self) -> None:
+    #     self.path.write_text(dumps(self._doc))
+    #     LOGGER.info("Saved updated TOML to %s", self.path)
+
+    def save(self, output_path: str | None = None) -> None:
+        path_to_write = self.path if output_path is None else pathlib.Path(output_path)
+        path_to_write.write_text(dumps(self._doc))
+        LOGGER.info("Saved updated TOML to %s", path_to_write)
 
     def get(self, key_path: list[str], default: Any = None) -> Any:
         obj: Any = self._doc
@@ -82,11 +87,20 @@ class TomlConfigEditor:
         )
 
 
-def update_run_metadata(config_path: str, run_id: str, experiment_id: str) -> None:
+def update_run_metadata(
+        config_path: str, 
+        run_id: str, 
+        experiment_id: str, 
+        extra_save_paths: list[str] | None = None,
+        ) -> None:
     editor = TomlConfigEditor(config_path)
     editor.update_field(["model", "run_id"], run_id)
     editor.update_field(["model", "experiment_id"], experiment_id)
     editor.save()
+    # Save to any additional paths provided, e.g. the model run folder
+    if extra_save_paths:
+        for path in extra_save_paths:
+            editor.save(output_path=path)
     editor.confirm_field(["model", "run_id"])
     editor.confirm_field(["model", "experiment_id"])
 
@@ -97,9 +111,13 @@ def update_key_courses_and_cips(
     key_course_subject_areas: list[str],
 ) -> None:
     """
-    Update the TOML config with key course IDs and cip codes under [preprocessing.features].
+    Update the TOML config with key course IDs and cip codes under [preprocessing.features],
+    and optionally save the updated config to one or more additional paths.
     """
     editor = TomlConfigEditor(config_path)
     editor.update_key_course_ids(key_course_ids)
     editor.update_key_course_subject_areas(key_course_subject_areas)
+
+    # Save to the original config path
     editor.save()
+


### PR DESCRIPTION
- Log the config in the folder named with the model id from a training run automatically so we can keep track of the exact config used to train that model
- Pull the inference config from the most recent registered model version's folder rather than the training inputs so that we are sure we are using the inference config from the model training. This also gets around the issue of the inference pipeline currently only looking for 'config.toml' in the training pipeline which was causing issues as we have multiple configs with different names for the same institution