### PR TITLE
feat: improve handle schema duplicates course num column

### DIFF
--- a/src/edvise/utils/data_cleaning.py
+++ b/src/edvise/utils/data_cleaning.py
@@ -774,6 +774,7 @@ def _renumber_duplicates(
     credits_col: str | None = "course_credits_attempted",
     course_type_col: str | None = "course_classification",
     course_name_col: str | None = "course_name",
+    course_number_col: str | None = "course_number",
 ) -> pd.DataFrame:
     """Renumber duplicate courses for schema mode."""
     if unique_cols is None:

--- a/src/edvise/utils/data_cleaning.py
+++ b/src/edvise/utils/data_cleaning.py
@@ -896,6 +896,7 @@ def _handle_schema_duplicates(
     credits_col: str | None = "course_credits_attempted",
     course_type_col: str | None = "course_classification",
     course_name_col: str | None = "course_name",
+    course_number_col: str | None = "course_number",
 ) -> pd.DataFrame:
     """Handle duplicates for Edvise schema mode."""
     LOGGER.info("handle_duplicates: edvise schema mode triggered")
@@ -948,6 +949,12 @@ def _handle_schema_duplicates(
     dropped_rows = len(drop_idx)
     df = _drop_true_duplicate_rows(df, drop_idx)
 
+    # Validate columns
+    if course_number_col in df.columns:
+        df[course_number_col] = df[course_number_col].astype("string").str.strip()
+    if "course_prefix" in df.columns:
+        df["course_prefix"] = df["course_prefix"].astype("string").str.strip()
+
     # Renumber duplicates
     df = _renumber_duplicates(
         df,
@@ -956,13 +963,11 @@ def _handle_schema_duplicates(
         credits_col,
         course_type_col,
         course_name_col,
+        course_number_col,
     )
 
     # Build course_id (always in schema mode)
-    df["course_id"] = (
-        df["course_prefix"].astype("string").str.strip()
-        + df["course_number"].astype("string").str.strip()
-    )
+    df["course_id"] = df["course_prefix"] + df[course_number_col]
 
     # Calculate summary statistics
     total_after = len(df)


### PR DESCRIPTION
- Cast course_number to string in _handle_schema_duplicates to prevent
  numeric coercion errors (380-1).
- Normalize key columns (strip + string cast).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to duplicate-cleaning logic that mainly normalizes string columns and adjusts `course_id` construction; low risk aside from potential downstream sensitivity to whitespace/casting differences.
> 
> **Overview**
> Improves Edvise schema duplicate handling by adding a `course_number_col` parameter to `_handle_schema_duplicates` and `_renumber_duplicates`, and using it when renumbering and building `course_id`.
> 
> After dropping keeper-selected duplicates, the code now normalizes key identifier columns by casting `course_number` (and `course_prefix`) to string and stripping whitespace, reducing issues where numeric ingestion/coercion breaks dedupe/ID creation (e.g., values like `380-1`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f22a58a3d989d728854da9df802fa23c6147896. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->