### PR TITLE
fix: databricks directory issues

### DIFF
--- a/src/edvise/scripts/pdp_gcp_databricks_ingestion.py
+++ b/src/edvise/scripts/pdp_gcp_databricks_ingestion.py
@@ -13,7 +13,7 @@ from google.api_core.exceptions import Forbidden, NotFound
 import google.auth
 
 # Ensure repo src/ is on sys.path so `import edvise.*` works in Databricks Jobs.
-script_dir = os.getcwd()
+script_dir = os.getcwd() 
 repo_root = os.path.abspath(os.path.join(script_dir, "..", "..", ".."))
 src_path = os.path.join(repo_root, "src")
 if os.path.isdir(src_path) and src_path not in sys.path:

--- a/src/edvise/scripts/pdp_gcp_databricks_ingestion.py
+++ b/src/edvise/scripts/pdp_gcp_databricks_ingestion.py
@@ -13,7 +13,7 @@ from google.api_core.exceptions import Forbidden, NotFound
 import google.auth
 
 # Ensure repo src/ is on sys.path so `import edvise.*` works in Databricks Jobs.
-script_dir = os.path.dirname(os.path.abspath(__file__))
+script_dir = os.getcwd()
 repo_root = os.path.abspath(os.path.join(script_dir, "..", "..", ".."))
 src_path = os.path.join(repo_root, "src")
 if os.path.isdir(src_path) and src_path not in sys.path:

--- a/src/edvise/scripts/pdp_gcp_databricks_ingestion.py
+++ b/src/edvise/scripts/pdp_gcp_databricks_ingestion.py
@@ -13,7 +13,7 @@ from google.api_core.exceptions import Forbidden, NotFound
 import google.auth
 
 # Ensure repo src/ is on sys.path so `import edvise.*` works in Databricks Jobs.
-script_dir = os.getcwd() 
+script_dir = os.getcwd()
 repo_root = os.path.abspath(os.path.join(script_dir, "..", "..", ".."))
 src_path = os.path.join(repo_root, "src")
 if os.path.isdir(src_path) and src_path not in sys.path:


### PR DESCRIPTION
## changes
- Updated the Databricks ingestion script in `src/edvise/scripts/pdp_gcp_databricks_ingestion.py` to use `os.getcwd()` instead of `os.path.dirname(os.path.abspath(__file__))` 

## context
- The ingestion task was not resolving paths as expected in the Databricks job environment. 

## questions
None.
