### PR TITLE
fix: classify gateway course level by first digit, not 200 threshold

### DIFF
--- a/src/edvise/data_audit/eda.py
+++ b/src/edvise/data_audit/eda.py
@@ -350,8 +350,9 @@ def compute_gateway_course_ids_and_cips(
     Returns: (ids, cips, has_upper_level_gateway, lower_ids, lower_cips)
       - ids: all gateway course IDs (M/E)
       - cips: CIP 2-digit codes from LOWER-LEVEL rows only (same as lower_cips)
-      - has_upper_level_gateway: True if any gateway course has level >=200
-      - lower_ids: gateway IDs with level <200
+      - has_upper_level_gateway: True if any gateway course's course_number has first digit >= 2
+        (after leading letters); works for any digit length (e.g. 10000 vs 20000).
+      - lower_ids: gateway IDs where that first digit is < 2
       - lower_cips: CIP 2-digit codes for lower_ids
     """
 
@@ -380,10 +381,15 @@ def compute_gateway_course_ids_and_cips(
         )
         return list(series)
 
-    def _last_level(num: pd.Series) -> pd.Series:
-        """Parse last numeric token, then last up-to-3 digits as integer level."""
-        tok = _s(num).str.extract(r"(\d+)(?!.*\d)", expand=True)[0]
-        return pd.to_numeric(tok.str[-3:], errors="coerce")
+    def _first_digit_after_leading_letters(num: pd.Series) -> pd.Series:
+        """
+        First digit of the numeric part of ``course_number``, after any leading letters
+        (e.g. ``ENG``) and non-digits (spaces, hyphens). Independent of how many digits
+        follow: ``10000`` → 1, ``2000`` → 2, ``20000`` → 2.
+        """
+        s = _s(num)
+        extracted = s.str.extract(r"^(?:[A-Za-z]+[^0-9]*)?(\d)", expand=True)[0]
+        return pd.to_numeric(extracted, errors="coerce")
 
     def _starts_with_any(arr: list[str], prefixes: list[str]) -> bool:
         arr = list(arr)  # handles numpy arrays / pandas .unique()
@@ -404,9 +410,9 @@ def compute_gateway_course_ids_and_cips(
         LOGGER.info(" No Math/English gateway courses found.")
         return ([], [], False, [], [])
 
-    level = _last_level(df_course["course_number"])  # full-length
-    upper_mask = is_gateway & level.ge(200).fillna(False)
-    lower_mask = is_gateway & level.lt(200).fillna(False)
+    first_digit = _first_digit_after_leading_letters(df_course["course_number"])
+    upper_mask = is_gateway & first_digit.ge(2).fillna(False)
+    lower_mask = is_gateway & first_digit.lt(2).fillna(False)
     has_upper_level_gateway = bool(upper_mask.any())
 
     # ---- IDs ----
@@ -422,7 +428,10 @@ def compute_gateway_course_ids_and_cips(
         + _s(df_course.loc[lower_mask, "course_number"])
     ).str.strip()
     lower_ids = lower_ids_series[lower_ids_series.ne("")].drop_duplicates().tolist()
-    LOGGER.info(" Identified %d lower-level (<200) gateway IDs.", len(lower_ids))
+    LOGGER.info(
+        " Identified %d lower-level (first course-number digit <2) gateway IDs.",
+        len(lower_ids),
+    )
 
     # ---- CIP extraction from LOWER rows only ----
     if "course_cip" in df_course.columns:
@@ -433,7 +442,10 @@ def compute_gateway_course_ids_and_cips(
                 " ⚠️ 'course_cip' present but yielded no lower-level CIP codes."
             )
         else:
-            LOGGER.info(" CIPs restricted to lower-level (<200) rows: %s", cips)
+            LOGGER.info(
+                " CIPs restricted to lower-level (first course-number digit <2) rows: %s",
+                cips,
+            )
     else:
         cips, lower_cips = [], []
         LOGGER.info(" No 'course_cip' column; skipping CIP extraction.")
@@ -446,8 +458,8 @@ def compute_gateway_course_ids_and_cips(
         ).str.strip()
         upper_ids = upper_ids_series[upper_ids_series.ne("")].drop_duplicates().tolist()
         LOGGER.warning(
-            " ⚠️ Warning: courses with level >=200 flagged as gateway (%d found). Course IDs: %s. "
-            "This is unusual; contact the school for more information.",
+            " ⚠️ Warning: courses with first course-number digit >=2 flagged as gateway "
+            "(%d found). Course IDs: %s. This is unusual; contact the school for more information.",
             len(upper_ids),
             upper_ids,
         )
@@ -457,7 +469,9 @@ def compute_gateway_course_ids_and_cips(
             len(lower_cips),
         )
     else:
-        LOGGER.info(" No gateway courses with level >=200 were detected.")
+        LOGGER.info(
+            " No gateway courses with first course-number digit >=2 were detected."
+        )
 
     # ---- prefix sanity check (compact) ----
     pref_e = (

--- a/src/edvise/scripts/pdp_data_audit.py
+++ b/src/edvise/scripts/pdp_data_audit.py
@@ -376,8 +376,9 @@ class PDPDataAuditTask:
                     and len(lower_cips) <= 10
                 ):
                     LOGGER.warning(
-                        " Upper-level (>=200) gateway courses detected. Auto-populating config with LOWER-level (<200) "
-                        "gateway courses and CIP codes only. Please confirm with the school and adjust if needed."
+                        " Upper-level gateway courses detected (first digit of course number >=2). "
+                        "Auto-populating config with lower-level (first digit <2) gateway courses and CIP codes only. "
+                        "Please confirm with the school and adjust if needed."
                     )
                     update_key_courses_and_cips(
                         self.args.config_file_path,

--- a/tests/data_audit/test_eda.py
+++ b/tests/data_audit/test_eda.py
@@ -645,3 +645,96 @@ class TestValidateCreditConsistencyPercent:
         assert "pct_of_data" in result["reconciliation_summary"]
         assert result["reconciliation_summary"]["mismatched_rows"] == 1
         assert result["reconciliation_summary"]["pct_of_data"] == round(100 * 1 / 3, 2)
+
+
+@pytest.mark.parametrize(
+    "course_number,expect_upper_level",
+    [
+        ("1023", False),
+        ("10000", False),
+        ("0995", False),
+        ("0123", False),
+        ("2034", True),
+        ("30456", True),
+        ("20000", True),
+        ("501", True),
+        ("9012", True),
+    ],
+    ids=[
+        "1023",
+        "10000",
+        "0995",
+        "0123",
+        "2034",
+        "30456",
+        "20000",
+        "501",
+        "9012",
+    ],
+)
+def test_compute_gateway_course_ids_first_digit_single_row(
+    course_number, expect_upper_level
+):
+    """First digit of numeric part (<2 vs >=2) for varied lengths: 1023, 2034, 30456, etc."""
+    df = pd.DataFrame(
+        {
+            "math_or_english_gateway": ["M"],
+            "course_prefix": ["MATH"],
+            "course_number": [course_number],
+            "course_cip": ["27.0101"],
+        }
+    )
+    _, _, has_upper, lower_ids, _ = data_audit.eda.compute_gateway_course_ids_and_cips(
+        df
+    )
+    assert has_upper is expect_upper_level
+    full_id = f"MATH{course_number}"
+    if expect_upper_level:
+        assert full_id not in lower_ids
+    else:
+        assert full_id in lower_ids
+
+
+def test_compute_gateway_course_ids_mixed_varied_lengths_in_one_frame():
+    """Multiple course numbers in one batch: lower = first digit 0–1, upper = 2–9."""
+    df = pd.DataFrame(
+        {
+            "math_or_english_gateway": ["M"] * 7,
+            "course_prefix": ["MATH"] * 7,
+            "course_number": [
+                "1023",
+                "10000",
+                "0995",
+                "2034",
+                "30456",
+                "20000",
+                "501",
+            ],
+            "course_cip": ["27.0101"] * 7,
+        }
+    )
+    ids, _, has_upper, lower_ids, _ = (
+        data_audit.eda.compute_gateway_course_ids_and_cips(df)
+    )
+    assert has_upper is True
+    assert set(lower_ids) == {"MATH1023", "MATH10000", "MATH0995"}
+    assert len(ids) == 7
+    for n in ("2034", "30456", "20000", "501"):
+        assert f"MATH{n}" not in lower_ids
+
+
+def test_compute_gateway_course_ids_prefix_plus_digits_after_letters():
+    """Digits after a letter prefix in course_number still use first numeric digit."""
+    df = pd.DataFrame(
+        {
+            "math_or_english_gateway": ["E"],
+            "course_prefix": [""],
+            "course_number": ["ENG10000"],
+            "course_cip": ["23.0101"],
+        }
+    )
+    _, _, has_upper, lower_ids, _ = data_audit.eda.compute_gateway_course_ids_and_cips(
+        df
+    )
+    assert has_upper is False
+    assert "ENG10000" in lower_ids


### PR DESCRIPTION
fix: classify gateway course level by first digit, not 200 threshold

Course numbers vary in length of digits (e.g. 1000); comparing to 200 misclassified courses for institutions that use longer course numbers. We now use the first digit after any leading letters (<2 = lower, ≥2 = upper) and align logs. Added unit tests for values like 1023, 2034, and 30456 to ensure new code works. Also tested on a school where I initially saw this issue in dev, and it worked.
