### PR TITLE
fix: model naming convention

### DIFF
--- a/src/edvise/modeling/registration.py
+++ b/src/edvise/modeling/registration.py
@@ -1,13 +1,10 @@
 import logging
 import re
 import typing as t
-from collections.abc import Iterable
 
 import mlflow
 import mlflow.exceptions
 import mlflow.tracking
-
-from edvise.utils import types as edvise_types
 
 from edvise.shared.utils import (
     format_enrollment_intensity_time_limits,
@@ -50,7 +47,7 @@ def _get_attr(obj: t.Any, key: str, default: t.Any = None) -> t.Any:
     return getattr(obj, key, default)
 
 
-def _retention_credential_suffix(raw: object) -> str:
+def _retention_credential_suffix(raw: str | list[str]) -> str:
     """
     Build the lowercase credential segment for retention model names.
 
@@ -60,11 +57,7 @@ def _retention_credential_suffix(raw: object) -> str:
     in config (e.g. ``ASSOCIATE'S DEGREE``, ``1-2 YEAR CERTIFICATE, LESS THAN
     ASSOCIATE DEGREE``); labels may contain the word "certificate".
     """
-    items = (
-        [str(x) for x in t.cast(Iterable[object], raw)]
-        if edvise_types.is_collection_but_not_string(raw)
-        else [str(raw)]
-    )
+    items = [str(x) for x in raw] if isinstance(raw, list) else [str(raw)]
     unique = list(dict.fromkeys(normalize_degree(x) for x in items))
     if len(unique) == 1:
         return unique[0].lower()
@@ -254,7 +247,10 @@ def pdp_get_model_name(
     if target_type == "retention":
         if "credential_type_sought_year_1" in student_criteria:
             credential = _retention_credential_suffix(
-                student_criteria["credential_type_sought_year_1"]
+                t.cast(
+                    str | list[str],
+                    student_criteria["credential_type_sought_year_1"],
+                )
             )
             target_name = f"retention_into_year_2_{credential}"
         else:

--- a/src/edvise/modeling/registration.py
+++ b/src/edvise/modeling/registration.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import typing as t
+from collections.abc import Iterable
 
 import mlflow
 import mlflow.exceptions
@@ -60,7 +61,7 @@ def _retention_credential_suffix(raw: object) -> str:
     ASSOCIATE DEGREE``); labels may contain the word "certificate".
     """
     items = (
-        [str(x) for x in raw]
+        [str(x) for x in t.cast(Iterable[object], raw)]
         if edvise_types.is_collection_but_not_string(raw)
         else [str(raw)]
     )

--- a/src/edvise/modeling/registration.py
+++ b/src/edvise/modeling/registration.py
@@ -1,9 +1,12 @@
 import logging
+import re
 import typing as t
 
 import mlflow
 import mlflow.exceptions
 import mlflow.tracking
+
+from edvise.utils import types as edvise_types
 
 from edvise.shared.utils import (
     format_enrollment_intensity_time_limits,
@@ -44,6 +47,36 @@ def _get_attr(obj: t.Any, key: str, default: t.Any = None) -> t.Any:
     if isinstance(obj, dict):
         return obj.get(key, default)
     return getattr(obj, key, default)
+
+
+def _retention_credential_suffix(raw: object) -> str:
+    """
+    Build the lowercase credential segment for retention model names.
+
+    Single value: ``normalize_degree(...).lower()``. Multiple distinct values:
+    short tokens sorted and joined with underscores; associates + certificate
+    becomes ``associates_and_cert``. Credential strings are typically uppercase
+    in config (e.g. ``ASSOCIATE'S DEGREE``, ``1-2 YEAR CERTIFICATE, LESS THAN
+    ASSOCIATE DEGREE``); labels may contain the word "certificate".
+    """
+    items = (
+        [str(x) for x in raw]
+        if edvise_types.is_collection_but_not_string(raw)
+        else [str(raw)]
+    )
+    unique = list(dict.fromkeys(normalize_degree(x) for x in items))
+    if len(unique) == 1:
+        return unique[0].lower()
+
+    def _tok(norm: str) -> str:
+        if re.search(r"\bcertificate\b", norm, re.IGNORECASE):
+            return "cert"
+        return "associates" if norm.lower() == "associates" else norm.lower()
+
+    toks = sorted(_tok(n) for n in unique)
+    if toks == ["associates", "cert"]:
+        return "associates_and_cert"
+    return "_".join(toks)
 
 
 def _checkpoint_suffix(
@@ -219,9 +252,9 @@ def pdp_get_model_name(
     # --- Retention ---
     if target_type == "retention":
         if "credential_type_sought_year_1" in student_criteria:
-            credential = normalize_degree(
+            credential = _retention_credential_suffix(
                 student_criteria["credential_type_sought_year_1"]
-            ).lower()
+            )
             target_name = f"retention_into_year_2_{credential}"
         else:
             target_name = "retention_into_year_2_all_degrees"

--- a/tests/modeling/test_registration.py
+++ b/tests/modeling/test_registration.py
@@ -377,6 +377,48 @@ class TestPDPGetModelName:
         )
         assert result == "retention_into_year_2_associates"
 
+    @pytest.mark.parametrize(
+        "second_credential",
+        [
+            "LESS THAN ONE-YEAR CERTIFICATE, LESS THAN ASSOCIATE DEGREE",
+            "ONE TO TWO YEAR CERTIFICATE, LESS THAN ASSOCIATE DEGREE",
+            "1-2 YEAR CERTIFICATE, LESS THAN ASSOCIATE DEGREE",
+            "2-4 YEAR CERTIFICATE, LESS THAN BACHELOR'S DEGREE",
+            "UNDERGRADUATE CERTIFICATE OR DIPLOMA PROGRAM",
+        ],
+    )
+    def test_retention_with_associates_and_certificate_selection(
+        self, second_credential: str
+    ) -> None:
+        """
+        Multi-select ASSOCIATE'S DEGREE + certificate-type credential → associates_and_cert.
+
+        Raw cohort schema keeps credential_type_sought_year_1 as strings (no remap);
+        configs use uppercase PDP-style values as ingested.
+        """
+        assert "certificate" in normalize_degree(second_credential).lower()
+
+        target = {
+            "type_": "retention",
+            "max_academic_year": "2024",
+        }
+        checkpoint = {
+            "type_": "first_within_cohort",
+        }
+        student_criteria = {
+            "credential_type_sought_year_1": [
+                "ASSOCIATE'S DEGREE",
+                second_credential,
+            ],
+        }
+
+        result = pdp_get_model_name(
+            target=target,
+            checkpoint=checkpoint,
+            student_criteria=student_criteria,
+        )
+        assert result == "retention_into_year_2_associates_and_cert"
+
     def test_retention_with_bachelor_degree(self):
         """Retention with Bachelor's degree variant"""
         target = {


### PR DESCRIPTION
Supports list-valued filters for credential_type_sought_year_1 so if a model has associates students AND certificate students, it can handle that when generating a model name and reflect that in the name.
Added unit tests for this and tested on dev as well. 