### PR TITLE
fix: EdaSummary: normalize Pell recipient counts (Y/YES vs No) in `pell_recipient_status`

### DIFF
--- a/src/edvise/data_audit/eda.py
+++ b/src/edvise/data_audit/eda.py
@@ -2229,27 +2229,27 @@ class EdaSummary:
         """
         Compute Pell recipient status without first generation split.
 
+        Only ``Y`` / ``YES`` (case-insensitive, trimmed) count as recipients; every other
+        value, including missing, ``N``, and unknown codes, is counted as non-recipient (No).
+
         Returns:
             Dictionary with keys:
                 - series: Single series with counts per Pell status
         """
-        if "pell_status_first_year" not in self.df_cohort.columns:
-            return None
-        if self.df_cohort["pell_status_first_year"].dropna().empty:
-            return None
-
+        s = (
+            self.df_cohort["pell_status_first_year"]
+            .astype("string")
+            .fillna("")
+            .str.strip()
+            .str.upper()
+        )
         data = (
-            self.df_cohort.assign(
-                pell_status_first_year=self.df_cohort["pell_status_first_year"]
-                .astype(str)
-                .str.strip()
-                .str.title()
-            )
-            .dropna(subset=["pell_status_first_year"])
-            .groupby("pell_status_first_year", observed=True)
-            .size()
+            pd.Series(np.where(s.isin(("Y", "YES")), "Yes", "No"), index=s.index)
+            .value_counts()
             .to_dict()
         )
+        if not data:
+            return None
         return {
             "series": [{"name": "All Students", "data": data}],
         }

--- a/tests/data_audit/test_eda.py
+++ b/tests/data_audit/test_eda.py
@@ -328,7 +328,7 @@ class TestEdaSummary:
 
     def test_pell_recipient_status(self, sample_cohort_data):
         assert EdaSummary(sample_cohort_data).pell_recipient_status == {
-            "series": [{"name": "All Students", "data": {"N": 1, "Nan": 6, "Y": 2}}]
+            "series": [{"name": "All Students", "data": {"No": 7, "Yes": 2}}]
         }
 
     def test_student_age_by_gender(self, sample_cohort_data):
@@ -351,13 +351,14 @@ class TestEdaSummary:
         }
 
     def test_pell_recipient_status_handles_nulls(self, sample_cohort_data):
-        """Test that NaN pell status values are properly excluded."""
+        """Missing pell status is imputed to No (same as N); series keys stay Yes/No."""
         sample_cohort_data.loc[0:2, "pell_status_first_year"] = pd.NA
         eda = EdaSummary(sample_cohort_data)
         result = eda.pell_recipient_status
         assert "series" in result
         data_keys = result["series"][0]["data"].keys()
         assert all(pd.notna(k) for k in data_keys)
+        assert set(data_keys) <= {"Yes", "No"}
 
     def test_student_age_by_gender_handles_nulls(self, sample_cohort_data):
         """Test that NaN gender values are properly excluded."""

--- a/tests/data_audit/test_eda.py
+++ b/tests/data_audit/test_eda.py
@@ -351,7 +351,7 @@ class TestEdaSummary:
         }
 
     def test_pell_recipient_status_handles_nulls(self, sample_cohort_data):
-        """Missing pell status is imputed to No (same as N); series keys stay Yes/No."""
+        """Missing pell status is imputed to No (same as N)"""
         sample_cohort_data.loc[0:2, "pell_status_first_year"] = pd.NA
         eda = EdaSummary(sample_cohort_data)
         result = eda.pell_recipient_status


### PR DESCRIPTION
## changes

- **`EdaSummary.pell_recipient_status`** (`src/edvise/data_audit/eda.py`): After normalizing `pell_status_first_year` with `astype("string")`, `fillna("")`, `strip`, and `upper`, treat only **`Y`** and **`YES`** as Pell recipients (**Yes**); all other values (including missing, **`N`**, and other codes) count as **No**.
- **Tests** (`tests/data_audit/test_eda.py`): Assert expected **Yes**/**No** totals on the sample cohort fixture; extend **`test_pell_recipient_status_handles_nulls`** so missing Pell values still yield only **Yes**/**No** keys (no stray `"nan"` / `NaN` bucket labels).

## context

- This change gets us aligned with the domain model for pell_recipient_status. Missing values should be treated as "No".

## questions

- None from the author


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213645756049928