### PR TITLE
feat: change shape of EdaSummary's enrollment_type_by_intensity to in…

### DIFF
--- a/src/edvise/data_audit/eda.py
+++ b/src/edvise/data_audit/eda.py
@@ -2143,10 +2143,10 @@ class EdaSummary:
 
         Returns:
             Dictionary with keys:
-                - categories: Sorted list of enrollment type names
-                - series: List of dictionaries with keys:
-                    - name: Enrollment intensity value (e.g., "Full-Time", "Part-Time")
-                    - data: List of counts per category
+                - total: Row count in the cross-tab (students with both fields)
+                - categories: Enrollment type names (stack axis)
+                - series: Per intensity, ``data`` is list of
+                  ``{ name, count, percentage }`` (percentage of total)
         """
         df = self.df_cohort.dropna(
             subset=["enrollment_type", "enrollment_intensity_first_term"]
@@ -2157,9 +2157,7 @@ class EdaSummary:
                 .astype(str)
                 .str.strip()
                 .str.title(),
-                enrollment_intensity_first_term=self.df_cohort[
-                    "enrollment_intensity_first_term"
-                ]
+                enrollment_intensity_first_term=df["enrollment_intensity_first_term"]
                 .astype(str)
                 .str.strip()
                 .str.title(),
@@ -2172,10 +2170,29 @@ class EdaSummary:
             .size()
             .unstack(fill_value=0)
         )
+        total = int(counts_df.to_numpy().sum())
+        if total == 0:
+            return {"total": 0, "categories": [], "series": []}
 
         return {
+            "total": total,
             "categories": counts_df.columns.tolist(),
-            "series": self._format_series_data(counts_df),
+            "series": [
+                {
+                    "name": str(intensity),
+                    "data": [
+                        {
+                            "name": str(cat),
+                            "count": int(counts_df.loc[intensity, cat]),
+                            "percentage": round(
+                                100 * counts_df.loc[intensity, cat] / total, 2
+                            ),
+                        }
+                        for cat in counts_df.columns
+                    ],
+                }
+                for intensity in counts_df.index
+            ],
         }
 
     @cached_property

--- a/tests/data_audit/test_eda.py
+++ b/tests/data_audit/test_eda.py
@@ -316,10 +316,35 @@ class TestEdaSummary:
 
     def test_enrollment_type_by_intensity(self, sample_cohort_data):
         assert EdaSummary(sample_cohort_data).enrollment_type_by_intensity == {
+            "total": 9,
             "categories": ["First-Time", "Transfer-In"],
             "series": [
-                {"name": "Full-Time", "data": [3.0, 5.0]},
-                {"name": "Part-Time", "data": [0.0, 1.0]},
+                {
+                    "name": "Full-Time",
+                    "data": [
+                        {
+                            "name": "First-Time",
+                            "count": 3,
+                            "percentage": 33.33,
+                        },
+                        {
+                            "name": "Transfer-In",
+                            "count": 5,
+                            "percentage": 55.56,
+                        },
+                    ],
+                },
+                {
+                    "name": "Part-Time",
+                    "data": [
+                        {"name": "First-Time", "count": 0, "percentage": 0},
+                        {
+                            "name": "Transfer-In",
+                            "count": 1,
+                            "percentage": 11.11,
+                        },
+                    ],
+                },
             ],
         }
 


### PR DESCRIPTION
## changes
Change the shape of EdaSummary's enrollment_type_by_intensity to include percentages

## context
The Student Enrollment Type by Intensity chart in the Edvise webapp calls for percentages to be displayed in the hovers. We provide the percentages here, and keep the UI focused on presentation.
