### PR TITLE
fix: resolve package-relative features table path in training validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,10 @@ name: deploy
 on:
   # deploy only when version tags are pushed
   push:
-    tags:
-      - 'v*'
+    # tags:
+    #   - 'v*'
+    branches:
+      - fix/training-features-table-path
 
 concurrency:
   group: deploy-prod-${{ github.ref_name }}-${{ github.job }}
@@ -12,104 +14,104 @@ concurrency:
 
 jobs:
   # PROD (staging-sst-01)
-  deploy-staging:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-    name: Deploy DAB to staging_sst_01 instance
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
+  # deploy-staging:
+  #   if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+  #   name: Deploy DAB to staging_sst_01 instance
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 60
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ github.ref }}
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11.11'
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: '3.11.11'
 
-      - name: Install uv and Databricks CLI
-        run: |
-          python -m pip install --upgrade pip
-          pip install uv
-          curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh
-          databricks -v
-        shell: bash
+  #     - name: Install uv and Databricks CLI
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install uv
+  #         curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh
+  #         databricks -v
+  #       shell: bash
 
-      - name: Install project dependencies (uv)
-        run: |
-          uv venv
-          uv pip install .
+  #     - name: Install project dependencies (uv)
+  #       run: |
+  #         uv venv
+  #         uv pip install .
 
-      - name: Configure Databricks env (Dev)
-        env:
-          DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
-          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_STAGING_CLIENT_ID }}
-          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_STAGING_CLIENT_SECRET }}
-        run: |
-          databricks version
+  #     - name: Configure Databricks env (Dev)
+  #       env:
+  #         DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
+  #         DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_STAGING_CLIENT_ID }}
+  #         DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_STAGING_CLIENT_SECRET }}
+  #       run: |
+  #         databricks version
 
-      - name: Deploy bundle (prod target -> staging_sst_01)
-        working-directory: pipelines/pdp
+  #     - name: Deploy bundle (prod target -> staging_sst_01)
+  #       working-directory: pipelines/pdp
 
-        env:
-          DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
-          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_STAGING_CLIENT_ID }}
-          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_STAGING_CLIENT_SECRET }}
-          SA_EXECUTER:          ${{ secrets.STAGING_SERVICE_ACCOUNT_EXECUTER }}
-          DS_RUN_AS:            ${{ secrets.STAGING_DS_RUN_AS }}
-          GROUP_TO_MANAGE:      ${{ secrets.GROUP_TO_MANAGE }}
-          DATAKIND_EMAIL:       ${{ secrets.DATAKIND_EMAIL }}
-        run: |
-          databricks current-user me
-          echo "Deploying DAB to prod for tag ${{ github.ref_name }}..."
-          databricks bundle deploy \
-            --target=prod \
-            --force-lock \
-            --var="service_account_executer=$SA_EXECUTER" \
-            --var="ds_run_as=$DS_RUN_AS" \
-            --var="databricks_institution_name=midway_uni" \
-            --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE" \
-            --var="datakind_notification_email=$DATAKIND_EMAIL" \
-            --var="git_tag=${{ github.ref_name }}"
+  #       env:
+  #         DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
+  #         DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_STAGING_CLIENT_ID }}
+  #         DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_STAGING_CLIENT_SECRET }}
+  #         SA_EXECUTER:          ${{ secrets.STAGING_SERVICE_ACCOUNT_EXECUTER }}
+  #         DS_RUN_AS:            ${{ secrets.STAGING_DS_RUN_AS }}
+  #         GROUP_TO_MANAGE:      ${{ secrets.GROUP_TO_MANAGE }}
+  #         DATAKIND_EMAIL:       ${{ secrets.DATAKIND_EMAIL }}
+  #       run: |
+  #         databricks current-user me
+  #         echo "Deploying DAB to prod for tag ${{ github.ref_name }}..."
+  #         databricks bundle deploy \
+  #           --target=prod \
+  #           --force-lock \
+  #           --var="service_account_executer=$SA_EXECUTER" \
+  #           --var="ds_run_as=$DS_RUN_AS" \
+  #           --var="databricks_institution_name=midway_uni" \
+  #           --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE" \
+  #           --var="datakind_notification_email=$DATAKIND_EMAIL" \
+  #           --var="git_tag=${{ github.ref_name }}"
 
-      - name: Deploy legacy bundle (prod target -> staging_sst_01)
-        working-directory: pipelines/legacy
-        env:
-          DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
-          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_STAGING_CLIENT_ID }}
-          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_STAGING_CLIENT_SECRET }}
-          SA_EXECUTER:          ${{ secrets.STAGING_SERVICE_ACCOUNT_EXECUTER }}
-          DS_RUN_AS:            ${{ secrets.STAGING_DS_RUN_AS }}
-          GROUP_TO_MANAGE:      ${{ secrets.GROUP_TO_MANAGE }}
-          DATAKIND_EMAIL:       ${{ secrets.DATAKIND_EMAIL }}
-        run: |
-          databricks bundle deploy \
-            --target=prod \
-            --force-lock \
-            --var="service_account_executer=$SA_EXECUTER" \
-            --var="ds_run_as=$DS_RUN_AS" \
-            --var="databricks_institution_name=midway_uni" \
-            --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE" \
-            --var="datakind_notification_email=$DATAKIND_EMAIL" \
-            --var="git_tag=${{ github.ref_name }}"
+  #     - name: Deploy legacy bundle (prod target -> staging_sst_01)
+  #       working-directory: pipelines/legacy
+  #       env:
+  #         DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
+  #         DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_STAGING_CLIENT_ID }}
+  #         DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_STAGING_CLIENT_SECRET }}
+  #         SA_EXECUTER:          ${{ secrets.STAGING_SERVICE_ACCOUNT_EXECUTER }}
+  #         DS_RUN_AS:            ${{ secrets.STAGING_DS_RUN_AS }}
+  #         GROUP_TO_MANAGE:      ${{ secrets.GROUP_TO_MANAGE }}
+  #         DATAKIND_EMAIL:       ${{ secrets.DATAKIND_EMAIL }}
+  #       run: |
+  #         databricks bundle deploy \
+  #           --target=prod \
+  #           --force-lock \
+  #           --var="service_account_executer=$SA_EXECUTER" \
+  #           --var="ds_run_as=$DS_RUN_AS" \
+  #           --var="databricks_institution_name=midway_uni" \
+  #           --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE" \
+  #           --var="datakind_notification_email=$DATAKIND_EMAIL" \
+  #           --var="git_tag=${{ github.ref_name }}"
 
-      - name: Deploy validated GCS to bronze sync bundle (prod target -> staging_sst_01)
-        working-directory: pipelines/ingestion/shared
-        env:
-          DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
-          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_STAGING_CLIENT_ID }}
-          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_STAGING_CLIENT_SECRET }}
-          SA_EXECUTER:          ${{ secrets.STAGING_SERVICE_ACCOUNT_EXECUTER }}
-          DS_RUN_AS:            ${{ secrets.STAGING_DS_RUN_AS }}
-          GROUP_TO_MANAGE:      ${{ secrets.GROUP_TO_MANAGE }}
-        run: |
-          databricks bundle deploy \
-            --target=prod \
-            --force-lock \
-            --var="service_account_executer=$SA_EXECUTER" \
-            --var="ds_run_as=$DS_RUN_AS" \
-            --var="databricks_institution_name=midway_uni" \
-            --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE" \
-            --var="git_tag=${{ github.ref_name }}"
+  #     - name: Deploy validated GCS to bronze sync bundle (prod target -> staging_sst_01)
+  #       working-directory: pipelines/ingestion/shared
+  #       env:
+  #         DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
+  #         DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_STAGING_CLIENT_ID }}
+  #         DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_STAGING_CLIENT_SECRET }}
+  #         SA_EXECUTER:          ${{ secrets.STAGING_SERVICE_ACCOUNT_EXECUTER }}
+  #         DS_RUN_AS:            ${{ secrets.STAGING_DS_RUN_AS }}
+  #         GROUP_TO_MANAGE:      ${{ secrets.GROUP_TO_MANAGE }}
+  #       run: |
+  #         databricks bundle deploy \
+  #           --target=prod \
+  #           --force-lock \
+  #           --var="service_account_executer=$SA_EXECUTER" \
+  #           --var="ds_run_as=$DS_RUN_AS" \
+  #           --var="databricks_institution_name=midway_uni" \
+  #           --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE" \
+  #           --var="git_tag=${{ github.ref_name }}"
 
   # DEV (dev-sst-02)
   deploy-dev:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,10 +3,8 @@ name: deploy
 on:
   # deploy only when version tags are pushed
   push:
-    # tags:
-    #   - 'v*'
-    branches:
-      - fix/training-features-table-path
+    tags:
+      - 'v*'
 
 concurrency:
   group: deploy-prod-${{ github.ref_name }}-${{ github.job }}
@@ -14,109 +12,108 @@ concurrency:
 
 jobs:
   # PROD (staging-sst-01)
-  # deploy-staging:
-  #   if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-  #   name: Deploy DAB to staging_sst_01 instance
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 60
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ github.ref }}
+  deploy-staging:
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    name: Deploy DAB to staging_sst_01 instance
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
 
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: '3.11.11'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11.11'
 
-  #     - name: Install uv and Databricks CLI
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install uv
-  #         curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh
-  #         databricks -v
-  #       shell: bash
+      - name: Install uv and Databricks CLI
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+          curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh
+          databricks -v
+        shell: bash
 
-  #     - name: Install project dependencies (uv)
-  #       run: |
-  #         uv venv
-  #         uv pip install .
+      - name: Install project dependencies (uv)
+        run: |
+          uv venv
+          uv pip install .
 
-  #     - name: Configure Databricks env (Dev)
-  #       env:
-  #         DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
-  #         DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_STAGING_CLIENT_ID }}
-  #         DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_STAGING_CLIENT_SECRET }}
-  #       run: |
-  #         databricks version
+      - name: Configure Databricks env (Dev)
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_STAGING_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_STAGING_CLIENT_SECRET }}
+        run: |
+          databricks version
 
-  #     - name: Deploy bundle (prod target -> staging_sst_01)
-  #       working-directory: pipelines/pdp
+      - name: Deploy bundle (prod target -> staging_sst_01)
+        working-directory: pipelines/pdp
 
-  #       env:
-  #         DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
-  #         DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_STAGING_CLIENT_ID }}
-  #         DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_STAGING_CLIENT_SECRET }}
-  #         SA_EXECUTER:          ${{ secrets.STAGING_SERVICE_ACCOUNT_EXECUTER }}
-  #         DS_RUN_AS:            ${{ secrets.STAGING_DS_RUN_AS }}
-  #         GROUP_TO_MANAGE:      ${{ secrets.GROUP_TO_MANAGE }}
-  #         DATAKIND_EMAIL:       ${{ secrets.DATAKIND_EMAIL }}
-  #       run: |
-  #         databricks current-user me
-  #         echo "Deploying DAB to prod for tag ${{ github.ref_name }}..."
-  #         databricks bundle deploy \
-  #           --target=prod \
-  #           --force-lock \
-  #           --var="service_account_executer=$SA_EXECUTER" \
-  #           --var="ds_run_as=$DS_RUN_AS" \
-  #           --var="databricks_institution_name=midway_uni" \
-  #           --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE" \
-  #           --var="datakind_notification_email=$DATAKIND_EMAIL" \
-  #           --var="git_tag=${{ github.ref_name }}"
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_STAGING_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_STAGING_CLIENT_SECRET }}
+          SA_EXECUTER:          ${{ secrets.STAGING_SERVICE_ACCOUNT_EXECUTER }}
+          DS_RUN_AS:            ${{ secrets.STAGING_DS_RUN_AS }}
+          GROUP_TO_MANAGE:      ${{ secrets.GROUP_TO_MANAGE }}
+          DATAKIND_EMAIL:       ${{ secrets.DATAKIND_EMAIL }}
+        run: |
+          databricks current-user me
+          echo "Deploying DAB to prod for tag ${{ github.ref_name }}..."
+          databricks bundle deploy \
+            --target=prod \
+            --force-lock \
+            --var="service_account_executer=$SA_EXECUTER" \
+            --var="ds_run_as=$DS_RUN_AS" \
+            --var="databricks_institution_name=midway_uni" \
+            --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE" \
+            --var="datakind_notification_email=$DATAKIND_EMAIL" \
+            --var="git_tag=${{ github.ref_name }}"
 
-  #     - name: Deploy legacy bundle (prod target -> staging_sst_01)
-  #       working-directory: pipelines/legacy
-  #       env:
-  #         DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
-  #         DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_STAGING_CLIENT_ID }}
-  #         DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_STAGING_CLIENT_SECRET }}
-  #         SA_EXECUTER:          ${{ secrets.STAGING_SERVICE_ACCOUNT_EXECUTER }}
-  #         DS_RUN_AS:            ${{ secrets.STAGING_DS_RUN_AS }}
-  #         GROUP_TO_MANAGE:      ${{ secrets.GROUP_TO_MANAGE }}
-  #         DATAKIND_EMAIL:       ${{ secrets.DATAKIND_EMAIL }}
-  #       run: |
-  #         databricks bundle deploy \
-  #           --target=prod \
-  #           --force-lock \
-  #           --var="service_account_executer=$SA_EXECUTER" \
-  #           --var="ds_run_as=$DS_RUN_AS" \
-  #           --var="databricks_institution_name=midway_uni" \
-  #           --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE" \
-  #           --var="datakind_notification_email=$DATAKIND_EMAIL" \
-  #           --var="git_tag=${{ github.ref_name }}"
+      - name: Deploy legacy bundle (prod target -> staging_sst_01)
+        working-directory: pipelines/legacy
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_STAGING_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_STAGING_CLIENT_SECRET }}
+          SA_EXECUTER:          ${{ secrets.STAGING_SERVICE_ACCOUNT_EXECUTER }}
+          DS_RUN_AS:            ${{ secrets.STAGING_DS_RUN_AS }}
+          GROUP_TO_MANAGE:      ${{ secrets.GROUP_TO_MANAGE }}
+          DATAKIND_EMAIL:       ${{ secrets.DATAKIND_EMAIL }}
+        run: |
+          databricks bundle deploy \
+            --target=prod \
+            --force-lock \
+            --var="service_account_executer=$SA_EXECUTER" \
+            --var="ds_run_as=$DS_RUN_AS" \
+            --var="databricks_institution_name=midway_uni" \
+            --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE" \
+            --var="datakind_notification_email=$DATAKIND_EMAIL" \
+            --var="git_tag=${{ github.ref_name }}"
 
-  #     - name: Deploy validated GCS to bronze sync bundle (prod target -> staging_sst_01)
-  #       working-directory: pipelines/ingestion/shared
-  #       env:
-  #         DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
-  #         DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_STAGING_CLIENT_ID }}
-  #         DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_STAGING_CLIENT_SECRET }}
-  #         SA_EXECUTER:          ${{ secrets.STAGING_SERVICE_ACCOUNT_EXECUTER }}
-  #         DS_RUN_AS:            ${{ secrets.STAGING_DS_RUN_AS }}
-  #         GROUP_TO_MANAGE:      ${{ secrets.GROUP_TO_MANAGE }}
-  #       run: |
-  #         databricks bundle deploy \
-  #           --target=prod \
-  #           --force-lock \
-  #           --var="service_account_executer=$SA_EXECUTER" \
-  #           --var="ds_run_as=$DS_RUN_AS" \
-  #           --var="databricks_institution_name=midway_uni" \
-  #           --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE" \
-  #           --var="git_tag=${{ github.ref_name }}"
+      - name: Deploy validated GCS to bronze sync bundle (prod target -> staging_sst_01)
+        working-directory: pipelines/ingestion/shared
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_STAGING_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_STAGING_CLIENT_SECRET }}
+          SA_EXECUTER:          ${{ secrets.STAGING_SERVICE_ACCOUNT_EXECUTER }}
+          DS_RUN_AS:            ${{ secrets.STAGING_DS_RUN_AS }}
+          GROUP_TO_MANAGE:      ${{ secrets.GROUP_TO_MANAGE }}
+        run: |
+          databricks bundle deploy \
+            --target=prod \
+            --force-lock \
+            --var="service_account_executer=$SA_EXECUTER" \
+            --var="ds_run_as=$DS_RUN_AS" \
+            --var="databricks_institution_name=midway_uni" \
+            --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE" \
+            --var="git_tag=${{ github.ref_name }}"
 
   # DEV (dev-sst-02)
   deploy-dev:
-    # TEMP: allow branch push for re-testing; revert before merge
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/fix/training-features-table-path' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
 
     name: Deploy DAB to dev_sst_02 instance
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,7 +115,8 @@ jobs:
 
   # DEV (dev-sst-02)
   deploy-dev:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    # TEMP: allow branch push for re-testing; revert before merge
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/fix/training-features-table-path' }}
 
     name: Deploy DAB to dev_sst_02 instance
     runs-on: ubuntu-latest

--- a/src/edvise/modeling/inference.py
+++ b/src/edvise/modeling/inference.py
@@ -232,9 +232,7 @@ def _get_mapped_feature_name(
 
     if lookup := _lookup_features_table_entry(feature_col, features_table):
         entry, match = lookup
-        feature_name = (
-            entry["name"].format(*match.groups()) if match else entry["name"]
-        )
+        feature_name = entry["name"].format(*match.groups()) if match else entry["name"]
         if metadata:
             short_desc, long_desc = _descs(entry)
             return feature_name, short_desc, long_desc

--- a/src/edvise/modeling/inference.py
+++ b/src/edvise/modeling/inference.py
@@ -198,6 +198,27 @@ def generate_ranked_feature_table(
     return df.drop(columns=["average_shap_magnitude_raw"])
 
 
+def _lookup_features_table_entry(
+    feature_col: str, features_table: dict[str, dict[str, str]]
+) -> tuple[dict[str, str], re.Match[str] | None] | None:
+    """Return ``(entry, regex_match)`` for an exact or regex features-table key."""
+    feature_col = feature_col.lower()
+    if feature_col in features_table:
+        return features_table[feature_col], None
+    for fkey, fval in features_table.items():
+        if "(" in fkey and ")" in fkey:
+            if match := re.fullmatch(fkey, feature_col):
+                return fval, match
+    return None
+
+
+def _is_feature_defined_in_table(
+    feature_col: str, features_table: dict[str, dict[str, str]]
+) -> bool:
+    """True when ``feature_col`` matches an exact or regex key in ``features_table``."""
+    return _lookup_features_table_entry(feature_col, features_table) is not None
+
+
 def _get_mapped_feature_name(
     feature_col: str, features_table: dict[str, dict[str, str]], metadata: bool = False
 ) -> t.Any:
@@ -209,22 +230,15 @@ def _get_mapped_feature_name(
         long_desc = entry.get("long_desc", entry.get("long_feature_desc"))
         return short_desc, long_desc
 
-    if feature_col in features_table:
-        entry = features_table[feature_col]
-        feature_name = entry["name"]
+    if lookup := _lookup_features_table_entry(feature_col, features_table):
+        entry, match = lookup
+        feature_name = (
+            entry["name"].format(*match.groups()) if match else entry["name"]
+        )
         if metadata:
             short_desc, long_desc = _descs(entry)
             return feature_name, short_desc, long_desc
         return feature_name
-    else:
-        for fkey, fval in features_table.items():
-            if "(" in fkey and ")" in fkey:
-                if match := re.fullmatch(fkey, feature_col):
-                    feature_name = fval["name"].format(*match.groups())
-                    if metadata:
-                        short_desc, long_desc = _descs(fval)
-                        return feature_name, short_desc, long_desc
-                    return feature_name
 
     try:
         for _, fval in features_table.items():

--- a/src/edvise/modeling/inference.py
+++ b/src/edvise/modeling/inference.py
@@ -212,7 +212,7 @@ def _lookup_features_table_entry(
     return None
 
 
-def _is_feature_defined_in_table(
+def is_feature_defined_in_table(
     feature_col: str, features_table: dict[str, dict[str, str]]
 ) -> bool:
     """True when ``feature_col`` matches an exact or regex key in ``features_table``."""

--- a/src/edvise/scripts/training_h2o.py
+++ b/src/edvise/scripts/training_h2o.py
@@ -319,7 +319,9 @@ class TrainingTask:
 
         # Check 1: All features exist in features_table (exact key or regex pattern)
         undefined_features = [
-            f for f in feature_cols if not _is_feature_defined_in_table(f, features_table)
+            f
+            for f in feature_cols
+            if not _is_feature_defined_in_table(f, features_table)
         ]
         if undefined_features:
             raise ValueError(

--- a/src/edvise/scripts/training_h2o.py
+++ b/src/edvise/scripts/training_h2o.py
@@ -307,14 +307,10 @@ class TrainingTask:
         1. All features in modeling dataset exist as keys in features_table
         2. All features have at least some non-null values
         """
-        import tomli
-
-        features_table_path = local_fs_path(self.spec.features_table_path)
+        features_table_path = self.spec.features_table_path
         logging.info("Validating features from: %s", features_table_path)
 
-        # Load features_table
-        with open(features_table_path, "rb") as f:
-            features_table = tomli.load(f)
+        features_table = dataio.read.read_features_table(features_table_path)
 
         # Get feature columns from modeling dataset
         non_feature_cols = set(self.cfg.non_feature_cols)

--- a/src/edvise/scripts/training_h2o.py
+++ b/src/edvise/scripts/training_h2o.py
@@ -54,7 +54,7 @@ from edvise.shared.validation import (
 )
 
 
-from edvise.modeling.inference import _is_feature_defined_in_table
+from edvise.modeling.inference import is_feature_defined_in_table
 from edvise.scripts.predictions_h2o import (
     PredConfig,
     PredPaths,
@@ -321,7 +321,7 @@ class TrainingTask:
         undefined_features = [
             f
             for f in feature_cols
-            if not _is_feature_defined_in_table(f, features_table)
+            if not is_feature_defined_in_table(f, features_table)
         ]
         if undefined_features:
             raise ValueError(

--- a/src/edvise/scripts/training_h2o.py
+++ b/src/edvise/scripts/training_h2o.py
@@ -54,6 +54,7 @@ from edvise.shared.validation import (
 )
 
 
+from edvise.modeling.inference import _is_feature_defined_in_table
 from edvise.scripts.predictions_h2o import (
     PredConfig,
     PredPaths,
@@ -304,7 +305,7 @@ class TrainingTask:
     def _validate_features_in_ft(self, df_modeling: pd.DataFrame) -> None:
         """
         Validate that:
-        1. All features in modeling dataset exist as keys in features_table
+        1. All features in modeling dataset match an exact or regex key in features_table
         2. All features have at least some non-null values
         """
         features_table_path = self.spec.features_table_path
@@ -316,9 +317,10 @@ class TrainingTask:
         non_feature_cols = set(self.cfg.non_feature_cols)
         feature_cols = [c for c in df_modeling.columns if c not in non_feature_cols]
 
-        # Check 1: All features exist in features_table
-        features_table_keys = set(features_table.keys())
-        undefined_features = [f for f in feature_cols if f not in features_table_keys]
+        # Check 1: All features exist in features_table (exact key or regex pattern)
+        undefined_features = [
+            f for f in feature_cols if not _is_feature_defined_in_table(f, features_table)
+        ]
         if undefined_features:
             raise ValueError(
                 f"Features in modeling dataset but not defined in features_table: {undefined_features}"

--- a/tests/modeling/test_inference.py
+++ b/tests/modeling/test_inference.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from edvise.modeling.inference import (
     _get_mapped_feature_name,
+    _is_feature_defined_in_table,
     select_top_features_for_display,
     generate_ranked_feature_table,
     top_shap_features,
@@ -355,6 +356,35 @@ def test_get_mapped_feature_name_no_metadata(feature_col, features_table, exp):
     obs = _get_mapped_feature_name(feature_col, features_table, metadata=False)
     assert isinstance(obs, str)
     assert obs == exp
+
+
+@pytest.mark.parametrize(
+    ["feature_col", "features_table", "exp_defined"],
+    [
+        ("academic_term", {"academic_term": {"name": "academic term"}}, True),
+        ("foo_bar", {"academic_term": {"name": "academic term"}}, False),
+        (
+            "num_courses_course_subject_area_51",
+            {
+                r"^num_courses_course_subject_area_(.*)$": {
+                    "name": "number of courses taken in subject area {} this term"
+                }
+            },
+            True,
+        ),
+        (
+            "cummax_in_12_creds_took_course_id_englb_101",
+            {
+                r"^cummax_in_12_creds_took_course_id_(.*)$": {
+                    "name": "course with id '{}' taken within student's first 12 credits"
+                }
+            },
+            True,
+        ),
+    ],
+)
+def test_is_feature_defined_in_table(feature_col, features_table, exp_defined):
+    assert _is_feature_defined_in_table(feature_col, features_table) is exp_defined
 
 
 @pytest.mark.parametrize(

--- a/tests/modeling/test_inference.py
+++ b/tests/modeling/test_inference.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from edvise.modeling.inference import (
     _get_mapped_feature_name,
-    _is_feature_defined_in_table,
+    is_feature_defined_in_table,
     select_top_features_for_display,
     generate_ranked_feature_table,
     top_shap_features,
@@ -383,8 +383,8 @@ def test_get_mapped_feature_name_no_metadata(feature_col, features_table, exp):
         ),
     ],
 )
-def test_is_feature_defined_in_table(feature_col, features_table, exp_defined):
-    assert _is_feature_defined_in_table(feature_col, features_table) is exp_defined
+def testis_feature_defined_in_table(feature_col, features_table, exp_defined):
+    assert is_feature_defined_in_table(feature_col, features_table) is exp_defined
 
 
 @pytest.mark.parametrize(

--- a/tests/modeling/test_inference.py
+++ b/tests/modeling/test_inference.py
@@ -383,7 +383,7 @@ def test_get_mapped_feature_name_no_metadata(feature_col, features_table, exp):
         ),
     ],
 )
-def testis_feature_defined_in_table(feature_col, features_table, exp_defined):
+def test_is_feature_defined_in_table(feature_col, features_table, exp_defined):
     assert is_feature_defined_in_table(feature_col, features_table) is exp_defined
 
 


### PR DESCRIPTION
## Summary
- Fix `FileNotFoundError` for `shared/assets/pdp_features_table.toml` during H2O training on Databricks
- Use `dataio.read.read_features_table()` in `_validate_features_in_ft` so the path resolves relative to the `edvise` package (same as inference/predictions)

## Test plan
- [ ] Re-run the failing training job on develop
- [ ] Confirm feature validation passes and training proceeds past `_validate_features_in_ft`


Made with [Cursor](https://cursor.com)