### PR TITLE
fix: calendar year codes inferred as datetime during cleaning

### DIFF
--- a/.github/workflows/deploy-genai-mapping.yml
+++ b/.github/workflows/deploy-genai-mapping.yml
@@ -17,10 +17,8 @@ name: deploy-genai-mapping
 
 on:
   push:
-    # tags:
-    #   - "v*"
-    branches:
-      - fix/calendar-year-code-dtype-inference
+    tags:
+      - "v*"
 concurrency:
   group: deploy-genai-mapping-${{ github.ref }}
   cancel-in-progress: true
@@ -69,46 +67,46 @@ jobs:
             --var "ds_run_as=$DS_RUN_AS" \
             --var "datakind_group_to_manage_workflow=$GROUP_TO_MANAGE"
 
-  # deploy-staging:
-  #   name: Deploy GenAI mapping bundle to staging (staging_sst_01)
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 30
-  #   steps:
-  #     - uses: actions/checkout@v4
+  deploy-staging:
+    name: Deploy GenAI mapping bundle to staging (staging_sst_01)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: "3.11.11"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11.11"
 
-  #     - name: Install uv and Databricks CLI
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install uv
-  #         curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh
-  #         databricks -v
-  #       shell: bash
+      - name: Install uv and Databricks CLI
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+          curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh
+          databricks -v
+        shell: bash
 
-  #     - name: Install project dependencies (uv)
-  #       run: |
-  #         uv venv
-  #         uv pip install .
+      - name: Install project dependencies (uv)
+        run: |
+          uv venv
+          uv pip install .
 
-  #     - name: Deploy bundle (staging_sst_01)
-  #       working-directory: pipelines/genai_mapping
-  #       env:
-  #         DATABRICKS_AUTH_TYPE: oauth-m2m
-  #         DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
-  #         DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_GENAI_MAPPING_STAGING_CLIENT_ID }}
-  #         DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_GENAI_MAPPING_STAGING_CLIENT_SECRET }}
-  #         SA_EXECUTER: ${{ secrets.STAGING_SERVICE_ACCOUNT_EXECUTER }}
-  #         DS_RUN_AS: ${{ secrets.DATABRICKS_GENAI_MAPPING_STAGING_CLIENT_ID }}
-  #         GROUP_TO_MANAGE: ${{ secrets.GROUP_TO_MANAGE }}
-  #       run: |
-  #         echo "Deploying staging_sst_01 with bundle target prod (git tag: ${GITHUB_REF_NAME})"
-  #         databricks bundle deploy \
-  #           --target=prod \
-  #           --force-lock \
-  #           --var "git_tag=${GITHUB_REF_NAME}" \
-  #           --var "service_account_executer=$SA_EXECUTER" \
-  #           --var "ds_run_as=$DS_RUN_AS" \
-  #           --var "datakind_group_to_manage_workflow=$GROUP_TO_MANAGE"
+      - name: Deploy bundle (staging_sst_01)
+        working-directory: pipelines/genai_mapping
+        env:
+          DATABRICKS_AUTH_TYPE: oauth-m2m
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_GENAI_MAPPING_STAGING_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_GENAI_MAPPING_STAGING_CLIENT_SECRET }}
+          SA_EXECUTER: ${{ secrets.STAGING_SERVICE_ACCOUNT_EXECUTER }}
+          DS_RUN_AS: ${{ secrets.DATABRICKS_GENAI_MAPPING_STAGING_CLIENT_ID }}
+          GROUP_TO_MANAGE: ${{ secrets.GROUP_TO_MANAGE }}
+        run: |
+          echo "Deploying staging_sst_01 with bundle target prod (git tag: ${GITHUB_REF_NAME})"
+          databricks bundle deploy \
+            --target=prod \
+            --force-lock \
+            --var "git_tag=${GITHUB_REF_NAME}" \
+            --var "service_account_executer=$SA_EXECUTER" \
+            --var "ds_run_as=$DS_RUN_AS" \
+            --var "datakind_group_to_manage_workflow=$GROUP_TO_MANAGE"

--- a/.github/workflows/deploy-genai-mapping.yml
+++ b/.github/workflows/deploy-genai-mapping.yml
@@ -17,8 +17,10 @@ name: deploy-genai-mapping
 
 on:
   push:
-    tags:
-      - "v*"
+    # tags:
+    #   - "v*"
+    branches:
+      - fix/calendar-year-code-dtype-inference
 concurrency:
   group: deploy-genai-mapping-${{ github.ref }}
   cancel-in-progress: true
@@ -67,46 +69,46 @@ jobs:
             --var "ds_run_as=$DS_RUN_AS" \
             --var "datakind_group_to_manage_workflow=$GROUP_TO_MANAGE"
 
-  deploy-staging:
-    name: Deploy GenAI mapping bundle to staging (staging_sst_01)
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
+  # deploy-staging:
+  #   name: Deploy GenAI mapping bundle to staging (staging_sst_01)
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 30
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11.11"
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: "3.11.11"
 
-      - name: Install uv and Databricks CLI
-        run: |
-          python -m pip install --upgrade pip
-          pip install uv
-          curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh
-          databricks -v
-        shell: bash
+  #     - name: Install uv and Databricks CLI
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install uv
+  #         curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh
+  #         databricks -v
+  #       shell: bash
 
-      - name: Install project dependencies (uv)
-        run: |
-          uv venv
-          uv pip install .
+  #     - name: Install project dependencies (uv)
+  #       run: |
+  #         uv venv
+  #         uv pip install .
 
-      - name: Deploy bundle (staging_sst_01)
-        working-directory: pipelines/genai_mapping
-        env:
-          DATABRICKS_AUTH_TYPE: oauth-m2m
-          DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
-          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_GENAI_MAPPING_STAGING_CLIENT_ID }}
-          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_GENAI_MAPPING_STAGING_CLIENT_SECRET }}
-          SA_EXECUTER: ${{ secrets.STAGING_SERVICE_ACCOUNT_EXECUTER }}
-          DS_RUN_AS: ${{ secrets.DATABRICKS_GENAI_MAPPING_STAGING_CLIENT_ID }}
-          GROUP_TO_MANAGE: ${{ secrets.GROUP_TO_MANAGE }}
-        run: |
-          echo "Deploying staging_sst_01 with bundle target prod (git tag: ${GITHUB_REF_NAME})"
-          databricks bundle deploy \
-            --target=prod \
-            --force-lock \
-            --var "git_tag=${GITHUB_REF_NAME}" \
-            --var "service_account_executer=$SA_EXECUTER" \
-            --var "ds_run_as=$DS_RUN_AS" \
-            --var "datakind_group_to_manage_workflow=$GROUP_TO_MANAGE"
+  #     - name: Deploy bundle (staging_sst_01)
+  #       working-directory: pipelines/genai_mapping
+  #       env:
+  #         DATABRICKS_AUTH_TYPE: oauth-m2m
+  #         DATABRICKS_HOST: ${{ secrets.DATABRICKS_STAGING_HOST }}
+  #         DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_GENAI_MAPPING_STAGING_CLIENT_ID }}
+  #         DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_GENAI_MAPPING_STAGING_CLIENT_SECRET }}
+  #         SA_EXECUTER: ${{ secrets.STAGING_SERVICE_ACCOUNT_EXECUTER }}
+  #         DS_RUN_AS: ${{ secrets.DATABRICKS_GENAI_MAPPING_STAGING_CLIENT_ID }}
+  #         GROUP_TO_MANAGE: ${{ secrets.GROUP_TO_MANAGE }}
+  #       run: |
+  #         echo "Deploying staging_sst_01 with bundle target prod (git tag: ${GITHUB_REF_NAME})"
+  #         databricks bundle deploy \
+  #           --target=prod \
+  #           --force-lock \
+  #           --var "git_tag=${GITHUB_REF_NAME}" \
+  #           --var "service_account_executer=$SA_EXECUTER" \
+  #           --var "ds_run_as=$DS_RUN_AS" \
+  #           --var "datakind_group_to_manage_workflow=$GROUP_TO_MANAGE"

--- a/src/edvise/data_audit/custom_cleaning.py
+++ b/src/edvise/data_audit/custom_cleaning.py
@@ -352,6 +352,32 @@ def _cast_series_to_nullable_dtype(
         raise ValueError(f"Failed to cast Series to {dtype_str}: {e}")
 
 
+_CALENDAR_YEAR_CODE_MIN = 1800
+_CALENDAR_YEAR_CODE_MAX = 2200
+
+
+def _is_calendar_year_code_series(series: pd.Series) -> bool:
+    """
+    True when every non-null value is a 4-digit token in a plausible calendar-year range.
+
+    Generic ``pd.to_datetime`` treats strings like ``"2021"`` as 2021-01-01; skip datetime
+    inference for these columns so year codes stay nullable Int64 (e.g. ``year_code``).
+    """
+    non_null = series.dropna()
+    if non_null.empty:
+        return False
+    tokens = non_null.astype("string").str.strip()
+    if not bool(tokens.str.fullmatch(r"\d{4}").all()):
+        return False
+    nums = pd.to_numeric(tokens, errors="coerce")
+    if not bool(nums.notna().all()):
+        return False
+    return bool(
+        (nums >= _CALENDAR_YEAR_CODE_MIN).all()
+        and (nums <= _CALENDAR_YEAR_CODE_MAX).all()
+    )
+
+
 def generate_column_training_dtype(
     series: pd.Series, opts: DtypeGenerationOptions | None = None
 ) -> pd.Series:
@@ -399,11 +425,13 @@ def generate_column_training_dtype(
         return count >= opts.min_non_null and frac >= opts.dtype_confidence_threshold
 
     # Skip datetime inference for CIP code columns (they often look like dates but are classification codes)
-    # Check column name if available (Series.name attribute)
+    # and for 4-digit calendar year codes (pd.to_datetime would map "2021" → 2021-01-01).
     col_name = getattr(s, "name", None)
-    skip_datetime_inference = col_name is not None and "cip" in str(col_name).lower()
+    skip_datetime_inference = (
+        col_name is not None and "cip" in str(col_name).lower()
+    ) or _is_calendar_year_code_series(s)
 
-    # Try declared date formats with coercion (skip for CIP columns)
+    # Try declared date formats with coercion (skip when datetime inference is disabled)
     if not skip_datetime_inference:
         for fmt in opts.date_formats:
             dt = pd.to_datetime(s, format=fmt, errors="coerce")

--- a/src/edvise/genai/mapping/identity_agent/term_normalization/term_order.py
+++ b/src/edvise/genai/mapping/identity_agent/term_normalization/term_order.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import pandas as pd
+import pandas.api.types as ptypes
 
 from edvise.utils.data_cleaning import convert_to_snake_case
 
@@ -93,6 +94,13 @@ def _norm_token(t: str | None) -> str | None:
     if s == "":
         return None
     return " ".join(s.lower().split())
+
+
+def _calendar_year_from_column(series: pd.Series) -> pd.Series:
+    """Extract calendar year from a split ``year_col`` (Int64, string year, or datetime)."""
+    if ptypes.is_datetime64_any_dtype(series):
+        return series.dt.year.astype("Int64")
+    return pd.to_numeric(series, errors="coerce").astype("Int64")
 
 
 def _resolve_season_token(t_norm: str | None, norm_keys: list[str]) -> str | None:
@@ -273,7 +281,7 @@ def add_edvise_term_order(
         for c in (year_col, season_col):
             if c not in out.columns:
                 raise KeyError(f"DataFrame must contain column '{c}'")
-        out[cols.year] = pd.to_numeric(out[year_col], errors="coerce").astype("Int64")
+        out[cols.year] = _calendar_year_from_column(out[year_col])
         s_season = out[season_col].astype("string").str.strip()
 
         def _cell_to_season_norm(val: object) -> str | None:

--- a/tests/data_audit/test_custom_cleaning.py
+++ b/tests/data_audit/test_custom_cleaning.py
@@ -401,6 +401,31 @@ def test_save_and_load_schema_contract_roundtrip(tmp_path):
     assert loaded == schema
 
 
+def test_generate_column_training_dtype_calendar_year_strings_stay_int64():
+    """Four-digit year codes must not be inferred as datetime (Indiana Tech year_code)."""
+    opts = DtypeGenerationOptions()
+    s = pd.Series(
+        ["2021", "2022", "2023", "2024", "2025"] * 500,
+        name="year_code",
+    )
+    out = generate_column_training_dtype(s, opts)
+    assert str(out.dtype) == "Int64"
+    assert int(out.iloc[0]) == 2021
+    assert int(out.iloc[-1]) == 2025
+
+
+def test_generate_training_dtypes_calendar_year_column():
+    df = pd.DataFrame(
+        {
+            "year_code": ["2021", "2022", "2023", "2024", "2025"] * 500,
+            "term_code": ["10", "20"] * 1250,
+        }
+    )
+    out = generate_training_dtypes(df, DtypeGenerationOptions())
+    assert str(out["year_code"].dtype) == "Int64"
+    assert str(out["term_code"].dtype) == "Int64"
+
+
 def test_generate_training_dtypes_respects_forced_dtypes():
     # Without forcing, both columns would be inferred as numeric:
     # - "id" → Int64

--- a/tests/genai/mapping/identity_agent/test_execution.py
+++ b/tests/genai/mapping/identity_agent/test_execution.py
@@ -683,6 +683,31 @@ def test_apply_term_order_split_year_season_columns():
     assert "_term_order" in out.columns
 
 
+def test_apply_term_order_split_year_datetime_coerced_from_strings():
+    """year_col inferred as datetime64 (legacy schemas) still yields calendar _year."""
+    df = pd.DataFrame(
+        {
+            "year_code": pd.to_datetime(["2021-01-01", "2022-01-01"]),
+            "term_code": ["10", "20"],
+            "k": [1, 2],
+        }
+    )
+    cfg = TermOrderConfig(
+        year_col="year_code",
+        season_col="term_code",
+        season_map=[
+            {"raw": "10", "canonical": "FALL"},
+            {"raw": "20", "canonical": "SPRING"},
+        ],
+        term_extraction="standard",
+    )
+    out = apply_term_order_from_config(df, cfg)
+    assert list(out["_year"]) == [2021, 2022]
+    assert list(out["_edvise_term_season"]) == ["FALL", "SPRING"]
+    assert out["_edvise_term_academic_year"].iloc[0] == "2021-22"
+    assert out["_edvise_term_academic_year"].iloc[1] == "2021-22"
+
+
 def test_apply_term_order_exclude_tokens_prefix():
     """HITL exclude_tokens: drop rows whose raw term values start with a listed prefix."""
     df = pd.DataFrame(


### PR DESCRIPTION
## Summary
- Skip generic `pd.to_datetime` dtype inference when all non-null values are 4-digit calendar year tokens (1800–2200), so columns like `year_code` stay `Int64` instead of becoming `datetime64[ns]`.
- Extract calendar year via `.dt.year` in split-column term order when `year_col` is already datetime, repairing legacy frozen schemas and producing correct `_edvise_term_academic_year` values.

## Test plan
- [x] `pytest tests/data_audit/test_custom_cleaning.py::test_generate_column_training_dtype_calendar_year_strings_stay_int64`
- [x] `pytest tests/data_audit/test_custom_cleaning.py::test_generate_training_dtypes_calendar_year_column`
- [x] `pytest tests/genai/mapping/identity_agent/test_execution.py::test_apply_term_order_split_year_datetime_coerced_from_strings`
- [x] Re-run problem school materialize/clean and confirm `year_code` is `Int64` and `_edvise_term_academic_year` values are like `2020-21`, not epoch nanoseconds


Made with [Cursor](https://cursor.com)