### PR TITLE
fix(genai): validate term hook groups at HITL emit time

### DIFF
--- a/src/edvise/genai/mapping/identity_agent/hitl/artifacts.py
+++ b/src/edvise/genai/mapping/identity_agent/hitl/artifacts.py
@@ -18,7 +18,13 @@ from edvise.genai.mapping.identity_agent.hitl.schemas import (
     InstitutionHITLItems,
 )
 from edvise.genai.mapping.identity_agent.profiling import RankedCandidateProfiles
-from edvise.genai.mapping.identity_agent.term_normalization.schemas import TermContract
+from edvise.genai.mapping.identity_agent.term_normalization.schemas import (
+    InstitutionTermContract,
+    TermContract,
+)
+from edvise.genai.mapping.identity_agent.term_normalization.validation import (
+    assert_term_hook_groups_compatible,
+)
 
 
 def build_grain_config_for_resolver(
@@ -108,6 +114,11 @@ def write_identity_term_artifacts(
     """
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+    inst_contract = InstitutionTermContract(
+        institution_id=institution_id,
+        datasets=dict(contracts_by_dataset),
+    )
+    assert_term_hook_groups_compatible(inst_contract, hitl_items)
     cfg = build_term_config_for_resolver(institution_id, contracts_by_dataset)
     env = InstitutionHITLItems(
         institution_id=institution_id,

--- a/src/edvise/genai/mapping/identity_agent/hitl/resolver.py
+++ b/src/edvise/genai/mapping/identity_agent/hitl/resolver.py
@@ -93,8 +93,12 @@ from edvise.genai.mapping.shared.hitl.json_io import (
 from edvise.genai.mapping.shared.hitl.run_log import RunEvent, append_run_log_event
 from edvise.genai.mapping.shared.hitl.time import utc_now_iso
 from edvise.genai.mapping.identity_agent.term_normalization.schemas import (
+    InstitutionTermContract,
     SeasonMapEntry,
     TermContract,
+)
+from edvise.genai.mapping.identity_agent.term_normalization.validation import (
+    assert_term_hook_groups_compatible,
 )
 
 logger = logging.getLogger(__name__)
@@ -563,6 +567,17 @@ def validate_term_hook_hitl_covers_hook_required(
             "hook_group_tables for its hook_group_id, or on another IDENTITY_TERM row sharing that "
             "hook_group_id. Batch-only hook_spec drafts do not satisfy hook generation."
         )
+
+    try:
+        assert_term_hook_groups_compatible(
+            InstitutionTermContract(
+                institution_id=envelope.institution_id,
+                datasets=term_contract_by_dataset,
+            ),
+            envelope.items,
+        )
+    except ValueError as e:
+        raise HITLValidationError(str(e)) from e
 
 
 # ---------------------------------------------------------------------------

--- a/src/edvise/genai/mapping/identity_agent/term_normalization/prompt.py
+++ b/src/edvise/genai/mapping/identity_agent/term_normalization/prompt.py
@@ -30,6 +30,7 @@ from .schemas import (
     TermContract,
     get_term_contract_schema_context,
 )
+from .validation import assert_term_hook_groups_compatible
 
 logger = logging.getLogger(__name__)
 
@@ -635,6 +636,11 @@ per table only when extraction logic truly differs; when logic is identical, use
 names (e.g. ``year_extractor_shared`` / ``season_extractor_shared``) in drafts. Do not merge
 distinct encodings into one group.
 
+**Hook group membership:** Only list a dataset in ``hook_group_tables`` when its ``term_config``
+uses ``term_col`` with ``term_extraction: "hook_required"``. Do **not** include tables that use
+split ``year_col`` + ``season_col`` (``term_extraction: "standard"``) — those need a separate
+season-map HITL item, not a shared combined-column hook.
+
 **Coverage:** Emit exactly one `TermContract`-shaped object per key under `datasets` in the
 input. Do not omit datasets.
 """
@@ -1186,6 +1192,7 @@ def parse_institution_term_contracts_with_hitl(
         d2, items = _strip_term_batch_hitl_payload(d)
         inst = InstitutionTermContract.model_validate(d2)
         _assert_term_batch_hitl_items_match_flags(inst, items)
+        assert_term_hook_groups_compatible(inst, items)
         return inst, items
     except Exception:
         text = raw if isinstance(raw, str) else str(raw)[:500]

--- a/src/edvise/genai/mapping/identity_agent/term_normalization/validation.py
+++ b/src/edvise/genai/mapping/identity_agent/term_normalization/validation.py
@@ -1,0 +1,136 @@
+"""
+Cross-table checks for term-stage GENERATE_HOOK HITL items and ``hook_group_tables``.
+
+Catches incompatible groupings at artifact emit time (before human review) so
+``apply_hook_spec`` does not fail late on split ``year_col``/``season_col`` configs.
+"""
+
+from __future__ import annotations
+
+from edvise.genai.mapping.identity_agent.hitl.schemas import (
+    HITLDomain,
+    HITLItem,
+    ReentryDepth,
+)
+from edvise.genai.mapping.identity_agent.term_normalization.schemas import (
+    InstitutionTermContract,
+    TermContract,
+    TermOrderConfig,
+)
+
+
+def term_tables_for_hook_group(
+    items: list[HITLItem],
+    group_id: str,
+) -> list[str]:
+    """
+    Dataset names that receive the same term hook fan-out as :func:`~edvise.genai.mapping.identity_agent.hitl.resolver.apply_hook_spec`.
+    """
+    tables: set[str] = set()
+    for item in items:
+        if item.domain == HITLDomain.IDENTITY_TERM and item.hook_group_id == group_id:
+            tables.add(item.table)
+            if item.hook_group_tables:
+                tables.update(item.hook_group_tables)
+    return sorted(tables)
+
+
+def item_has_generate_hook_path(item: HITLItem) -> bool:
+    """True when any option on the item uses ``reentry='generate_hook'``."""
+    return any(opt.reentry == ReentryDepth.GENERATE_HOOK for opt in item.options)
+
+
+def _term_config_hook_target_label(cfg: TermOrderConfig | None) -> str:
+    if cfg is None:
+        return "term_config is null"
+    if cfg.term_col is not None:
+        return f"term_col={cfg.term_col!r}"
+    if cfg.year_col is not None and cfg.season_col is not None:
+        return f"year_col={cfg.year_col!r}, season_col={cfg.season_col!r}"
+    return "no term column configured"
+
+
+def _assert_table_hook_group_compatible(
+    *,
+    table: str,
+    contract: TermContract,
+    item_id: str,
+) -> None:
+    cfg = contract.term_config
+    if cfg is None:
+        raise ValueError(
+            f"Term batch JSON: HITL item {item_id!r} targets dataset {table!r} for hook "
+            "generation, but term_config is null."
+        )
+    has_split = cfg.year_col is not None and cfg.season_col is not None
+    has_term_col = cfg.term_col is not None
+    if has_split and not has_term_col:
+        raise ValueError(
+            f"Term batch JSON: dataset {table!r} is listed for GENERATE_HOOK item "
+            f"{item_id!r} but uses split year_col/season_col without term_col "
+            f"({_term_config_hook_target_label(cfg)}). "
+            "Split-column tables cannot share a combined-column hook group — use "
+            "term_extraction='standard' with season_map for that table and omit it from "
+            "hook_group_tables, or set term_col on the term_config."
+        )
+    if cfg.term_extraction != "hook_required":
+        raise ValueError(
+            f"Term batch JSON: dataset {table!r} is listed for GENERATE_HOOK item "
+            f"{item_id!r} but term_extraction={cfg.term_extraction!r} "
+            f"({_term_config_hook_target_label(cfg)}). "
+            "Every table in a hook group must use term_extraction='hook_required' with "
+            "term_col set."
+        )
+    if not has_term_col:
+        raise ValueError(
+            f"Term batch JSON: dataset {table!r} is listed for GENERATE_HOOK item "
+            f"{item_id!r} but has no term_col ({_term_config_hook_target_label(cfg)})."
+        )
+
+
+def assert_term_hook_groups_compatible(
+    inst: InstitutionTermContract,
+    items: list[HITLItem],
+) -> None:
+    """
+    Validate GENERATE_HOOK term HITL items against per-dataset term_config shapes.
+
+    Raises ``ValueError`` when a hook group (or single-table generate_hook item) would
+    fail at :func:`~edvise.genai.mapping.identity_agent.hitl.resolver.apply_hook_spec`.
+    """
+    seen_groups: set[str] = set()
+    for item in items:
+        if item.domain != HITLDomain.IDENTITY_TERM:
+            continue
+        if not item_has_generate_hook_path(item):
+            continue
+
+        if item.hook_group_id:
+            gid = item.hook_group_id
+            if gid in seen_groups:
+                continue
+            seen_groups.add(gid)
+            target_tables = term_tables_for_hook_group(items, gid)
+            anchor_item_id = item.item_id
+        else:
+            target_tables = [item.table]
+
+        for table in target_tables:
+            contract = inst.datasets.get(table)
+            if contract is None:
+                raise ValueError(
+                    f"Term batch JSON: HITL item {item.item_id!r} references dataset "
+                    f"{table!r}, which is missing from datasets."
+                )
+            _assert_table_hook_group_compatible(
+                table=table,
+                contract=contract,
+                item_id=anchor_item_id if item.hook_group_id else item.item_id,
+            )
+
+
+__all__ = [
+    "assert_term_hook_groups_compatible",
+    "item_has_generate_hook_path",
+    "term_tables_for_hook_group",
+]

--- a/tests/genai/mapping/identity_agent/test_term_validation.py
+++ b/tests/genai/mapping/identity_agent/test_term_validation.py
@@ -1,0 +1,218 @@
+"""Emit-time validation for term hook_group_tables vs term_config column shapes."""
+
+import json
+
+import pytest
+
+from edvise.genai.mapping.identity_agent.grain_inference.schemas import (
+    HookFunctionSpec,
+    HookSpec,
+)
+from edvise.genai.mapping.identity_agent.hitl.artifacts import write_identity_term_artifacts
+from edvise.genai.mapping.identity_agent.hitl.resolver import (
+    HITLValidationError,
+    validate_term_hook_hitl_covers_hook_required,
+)
+from edvise.genai.mapping.identity_agent.hitl.schemas import (
+    HITLDomain,
+    HITLItem,
+    HITLOption,
+    HITLTarget,
+    InstitutionHITLItems,
+    ReentryDepth,
+    TermResolution,
+)
+from edvise.genai.mapping.identity_agent.term_normalization.prompt import (
+    parse_institution_term_contracts_with_hitl,
+)
+from edvise.genai.mapping.identity_agent.term_normalization.schemas import (
+    InstitutionTermContract,
+    TermContract,
+    TermOrderConfig,
+)
+from edvise.genai.mapping.identity_agent.term_normalization.validation import (
+    assert_term_hook_groups_compatible,
+)
+
+INST = "indiana_institute_of_technology"
+
+
+def _hook_spec() -> HookSpec:
+    return HookSpec(
+        file=f"identity_hooks/{INST}/term_hooks.py",
+        functions=[
+            HookFunctionSpec(
+                name="year_extractor_shared",
+                signature="def year_extractor_shared(term: str) -> int",
+                description="year",
+                draft="int(str(term).split('-')[0]) if '-' in str(term) else None",
+            ),
+            HookFunctionSpec(
+                name="season_extractor_shared",
+                signature="def season_extractor_shared(term: str) -> str",
+                description="season",
+                draft=(
+                    "str(term).split('-')[1] if '-' in str(term) else str(term)"
+                ),
+            ),
+        ],
+    )
+
+
+def _hook_term_contract(table: str, *, term_col: str) -> TermContract:
+    return TermContract(
+        institution_id=INST,
+        table=table,
+        term_config=TermOrderConfig(
+            term_col=term_col,
+            season_map=[],
+            term_extraction="hook_required",
+            hook_spec=_hook_spec(),
+        ),
+        confidence=0.75,
+        hitl_flag=True,
+        reasoning="opaque combined term encoding",
+    )
+
+
+def _split_standard_student() -> TermContract:
+    return TermContract(
+        institution_id=INST,
+        table="student",
+        term_config=TermOrderConfig(
+            year_col="year_col",
+            season_col="term_code",
+            season_map=[],
+            term_extraction="standard",
+        ),
+        confidence=0.85,
+        hitl_flag=True,
+        reasoning="split year and opaque season codes",
+    )
+
+
+def _shared_hitl_item() -> HITLItem:
+    resolution = TermResolution(
+        hook_spec=_hook_spec(),
+        season_map_replace=[
+            {"raw": "10", "canonical": "FALL"},
+            {"raw": "20", "canonical": "SPRING"},
+        ],
+    )
+    return HITLItem(
+        item_id="shared_term_encoding_season_map_confirmation",
+        institution_id=INST,
+        table="student",
+        domain=HITLDomain.IDENTITY_TERM,
+        hook_group_id="shared_term_encoding_iit",
+        hook_group_tables=["student", "course", "semester"],
+        hitl_question="Confirm season mapping",
+        hitl_context="student uses 10/20; course uses YYYY-TT",
+        options=[
+            HITLOption(
+                option_id="confirm_10_fall_20_spring",
+                label="10→FALL, 20→SPRING",
+                description="confirm",
+                resolution=resolution.model_dump(mode="json"),
+                reentry=ReentryDepth.GENERATE_HOOK,
+            ),
+            HITLOption(
+                option_id="custom",
+                label="Custom",
+                description="custom",
+                resolution=TermResolution(
+                    season_map_replace=resolution.season_map_replace
+                ).model_dump(mode="json"),
+                reentry=ReentryDepth.GENERATE_HOOK,
+            ),
+        ],
+        target=HITLTarget(
+            institution_id=INST,
+            table="student",
+            config="term_config",
+            field="season_map",
+        ),
+    )
+
+
+def test_assert_term_hook_groups_compatible_valid_group():
+    inst = InstitutionTermContract(
+        institution_id=INST,
+        datasets={
+            "student": _hook_term_contract("student", term_col="term_col"),
+            "course": _hook_term_contract("course", term_col="semester"),
+        },
+    )
+    item = _shared_hitl_item()
+    item.hook_group_tables = ["student", "course"]
+    assert_term_hook_groups_compatible(inst, [item])
+
+
+def test_assert_term_hook_groups_compatible_rejects_split_student_in_group():
+    inst = InstitutionTermContract(
+        institution_id=INST,
+        datasets={
+            "student": _split_standard_student(),
+            "course": _hook_term_contract("course", term_col="semester"),
+            "semester": _hook_term_contract("semester", term_col="semester"),
+        },
+    )
+    with pytest.raises(ValueError, match="split year_col/season_col"):
+        assert_term_hook_groups_compatible(inst, [_shared_hitl_item()])
+
+
+def test_parse_institution_term_contracts_with_hitl_rejects_bad_hook_group(
+    tmp_path,
+):
+    payload = {
+        "institution_id": INST,
+        "datasets": {
+            "student": _split_standard_student().model_dump(mode="json"),
+            "course": _hook_term_contract("course", term_col="semester").model_dump(
+                mode="json"
+            ),
+            "semester": _hook_term_contract(
+                "semester", term_col="semester"
+            ).model_dump(mode="json"),
+        },
+        "hitl_items": [_shared_hitl_item().model_dump(mode="json")],
+    }
+    with pytest.raises(ValueError, match="split year_col/season_col"):
+        parse_institution_term_contracts_with_hitl(json.dumps(payload))
+
+
+def test_write_identity_term_artifacts_rejects_bad_hook_group(tmp_path):
+    contracts = {
+        "student": _split_standard_student(),
+        "course": _hook_term_contract("course", term_col="semester"),
+    }
+    with pytest.raises(ValueError, match="split year_col/season_col"):
+        write_identity_term_artifacts(
+            tmp_path,
+            INST,
+            contracts,
+            [_shared_hitl_item()],
+        )
+
+
+def test_validate_term_hook_hitl_covers_hook_required_rejects_bad_group(tmp_path):
+    hitl_path = tmp_path / "identity_term_hitl.json"
+    item = _shared_hitl_item()
+    item.choice = 1
+    hitl_path.write_text(
+        InstitutionHITLItems(
+            institution_id=INST,
+            domain="term",
+            items=[item],
+        ).model_dump_json(indent=2)
+    )
+    contracts = {
+        "student": _split_standard_student(),
+        "course": _hook_term_contract("course", term_col="semester"),
+        "semester": _hook_term_contract("semester", term_col="semester"),
+    }
+    with pytest.raises(HITLValidationError, match="split year_col/season_col"):
+        validate_term_hook_hitl_covers_hook_required(
+            term_hitl_path=hitl_path,
+            term_contract_by_dataset=contracts,
+        )

--- a/tests/genai/mapping/identity_agent/test_term_validation.py
+++ b/tests/genai/mapping/identity_agent/test_term_validation.py
@@ -8,7 +8,9 @@ from edvise.genai.mapping.identity_agent.grain_inference.schemas import (
     HookFunctionSpec,
     HookSpec,
 )
-from edvise.genai.mapping.identity_agent.hitl.artifacts import write_identity_term_artifacts
+from edvise.genai.mapping.identity_agent.hitl.artifacts import (
+    write_identity_term_artifacts,
+)
 from edvise.genai.mapping.identity_agent.hitl.resolver import (
     HITLValidationError,
     validate_term_hook_hitl_covers_hook_required,
@@ -51,9 +53,7 @@ def _hook_spec() -> HookSpec:
                 name="season_extractor_shared",
                 signature="def season_extractor_shared(term: str) -> str",
                 description="season",
-                draft=(
-                    "str(term).split('-')[1] if '-' in str(term) else str(term)"
-                ),
+                draft=("str(term).split('-')[1] if '-' in str(term) else str(term)"),
             ),
         ],
     )
@@ -171,9 +171,9 @@ def test_parse_institution_term_contracts_with_hitl_rejects_bad_hook_group(
             "course": _hook_term_contract("course", term_col="semester").model_dump(
                 mode="json"
             ),
-            "semester": _hook_term_contract(
-                "semester", term_col="semester"
-            ).model_dump(mode="json"),
+            "semester": _hook_term_contract("semester", term_col="semester").model_dump(
+                mode="json"
+            ),
         },
         "hitl_items": [_shared_hitl_item().model_dump(mode="json")],
     }
@@ -185,6 +185,7 @@ def test_write_identity_term_artifacts_rejects_bad_hook_group(tmp_path):
     contracts = {
         "student": _split_standard_student(),
         "course": _hook_term_contract("course", term_col="semester"),
+        "semester": _hook_term_contract("semester", term_col="semester"),
     }
     with pytest.raises(ValueError, match="split year_col/season_col"):
         write_identity_term_artifacts(


### PR DESCRIPTION
## Summary
- Add `term_normalization/validation.py` to reject incompatible `hook_group_tables` when a GENERATE_HOOK HITL item is emitted (split `year_col`/`season_col` tables cannot share a combined-column hook group).
- Wire validation at LLM parse time, artifact write, and `gate_1` (`validate_term_hook_hitl_covers_hook_required`) so failures surface before human review instead of during `apply_hook_spec`.
- Update term batch prompt guidance and add IIT-shaped regression tests.

## Test plan
- [x] `uv run pytest tests/genai/mapping/identity_agent/test_term_validation.py -q`


Made with [Cursor](https://cursor.com)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215785632336179