### PR TITLE
fix: systemic optional-column guards for ES feature generation

### DIFF
--- a/src/edvise/feature_generation/es_feature_specs.py
+++ b/src/edvise/feature_generation/es_feature_specs.py
@@ -117,6 +117,7 @@ def build_edvise_feature_specs(
             df_course,
             course_cols,
             course_flags=course,
+            section_flags=section,
         ),
         o.student_term_aggregate,
     )

--- a/src/edvise/feature_generation/feature_dependencies.py
+++ b/src/edvise/feature_generation/feature_dependencies.py
@@ -32,7 +32,11 @@ def filter_named_aggs(
 
 # --- Downstream inputs required by student-term aggregate / add steps ---
 
-MULTICOL_GRADE_COLUMNS = ("grade", "course_grade_numeric", "section_course_grade_numeric_mean")
+MULTICOL_GRADE_COLUMNS = (
+    "grade",
+    "course_grade_numeric",
+    "section_course_grade_numeric_mean",
+)
 
 SECTION_STUDENT_FRACTION_COLUMNS = (
     "sections_num_students_enrolled",

--- a/src/edvise/feature_generation/feature_dependencies.py
+++ b/src/edvise/feature_generation/feature_dependencies.py
@@ -1,0 +1,61 @@
+"""
+Column-presence helpers and cross-step feature dependencies for feature generation.
+
+Upstream specs (:mod:`feature_resolution`) decide which features *should* be built from
+raw inputs. Downstream steps (:mod:`student_term`, :mod:`cumulative`) must only consume
+columns that actually exist on the frame — ES institutions often omit optional PDP fields.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from .column_names import CourseFeatureSpec, SectionFeatureSpec
+
+
+def columns_present(df: pd.DataFrame, *names: str) -> bool:
+    """True when every name is a column on ``df``."""
+    return bool(names) and all(name in df.columns for name in names)
+
+
+def enable_when(spec_flag: bool, df: pd.DataFrame, *required_columns: str) -> bool:
+    """Combine a resolved spec toggle with a runtime column-presence check."""
+    return spec_flag and columns_present(df, *required_columns)
+
+
+def filter_named_aggs(
+    df: pd.DataFrame, aggs: dict[str, pd.NamedAgg]
+) -> dict[str, pd.NamedAgg]:
+    """Keep only NamedAgg entries whose source column exists on ``df``."""
+    return {key: named for key, named in aggs.items() if named.column in df.columns}
+
+
+# --- Downstream inputs required by student-term aggregate / add steps ---
+
+MULTICOL_GRADE_COLUMNS = ("grade", "course_grade_numeric", "section_course_grade_numeric_mean")
+
+SECTION_STUDENT_FRACTION_COLUMNS = (
+    "sections_num_students_enrolled",
+    "sections_num_students_passed",
+    "sections_num_students_completed",
+)
+
+STUDENT_RATE_VS_SECTION_COLUMNS = (
+    "frac_courses_passed",
+    "frac_courses_completed",
+    "frac_sections_students_passed",
+    "frac_sections_students_completed",
+)
+
+
+def multicol_grade_enabled(
+    *,
+    course_flags: CourseFeatureSpec,
+    section_flags: SectionFeatureSpec,
+) -> bool:
+    """Grade-vs-section aggregates need course grades and section-level grade means."""
+    return bool(
+        course_flags.course_grade
+        and course_flags.course_grade_numeric
+        and section_flags.section_course_grade_numeric_mean
+    )

--- a/src/edvise/feature_generation/feature_resolution.py
+++ b/src/edvise/feature_generation/feature_resolution.py
@@ -216,6 +216,9 @@ def resolve_student_term_add_feature_spec(
     )
     will_have_cohort_start = has_cohort_keys
     has_term_prog = has_data_col(df_course, course_cols.term_program_of_study)
+    # ``num_courses_in_term_program_of_study_area`` needs aggregated ``course_subject_areas``,
+    # which requires raw CIP/department (see course.add_features / summary aggs).
+    has_course_subject_areas = has_data_col(df_course, course_cols.course_cip)
     has_cr = has_data_col(
         df_course, course_cols.number_of_credits_earned
     ) and has_data_col(df_course, course_cols.number_of_credits_attempted)
@@ -233,7 +236,7 @@ def resolve_student_term_add_feature_spec(
         ),
         program_of_study_area=has_term_prog,
         credit_fraction_and_intensity=has_cr,
-        num_courses_in_program_area=has_term_prog,
+        num_courses_in_program_area=has_term_prog and has_course_subject_areas,
         num_course_by_category_fracs=True,
         section_student_fractions=bool(section_enrolled and g),
         student_rate_vs_section_fractions=bool(section_enrolled and g),

--- a/src/edvise/feature_generation/feature_resolution.py
+++ b/src/edvise/feature_generation/feature_resolution.py
@@ -23,6 +23,7 @@ from .column_names import (
     TermFeatureSpec,
     ES_STUDENT_FEATURE_SPEC_DEFAULT,
 )
+from .feature_dependencies import multicol_grade_enabled
 
 _TSpec = t.TypeVar("_TSpec")
 
@@ -161,6 +162,7 @@ def resolve_student_term_aggregate_spec(
     cols: CourseInputColumns,
     *,
     course_flags: CourseFeatureSpec,
+    section_flags: SectionFeatureSpec,
 ) -> StudentTermAggregateSpec:
     g = has_data_col(df, cols.grade)
     pfx = has_data_col(df, cols.course_prefix)
@@ -181,7 +183,9 @@ def resolve_student_term_aggregate_spec(
         summary_aggregations=True,
         dummies=dummies,
         value_equality=bool(value_equality),
-        multicol_grade=bool(g),
+        multicol_grade=multicol_grade_enabled(
+            course_flags=course_flags, section_flags=section_flags
+        ),
     )
 
 

--- a/src/edvise/feature_generation/student_term.py
+++ b/src/edvise/feature_generation/student_term.py
@@ -309,7 +309,10 @@ def add_features(
     if enable_when(s.program_of_study_area, df, cols.term_program_of_study):
         batch1["term_program_of_study_area"] = term_program_of_study_area
     if enable_when(
-        s.credit_fraction_and_intensity, df, "num_credits_attempted", "num_credits_earned"
+        s.credit_fraction_and_intensity,
+        df,
+        "num_credits_attempted",
+        "num_credits_earned",
     ):
         batch1["frac_credits_earned"] = shared.frac_credits_earned
         batch1["student_term_enrollment_intensity"] = ft.partial(

--- a/src/edvise/feature_generation/student_term.py
+++ b/src/edvise/feature_generation/student_term.py
@@ -55,6 +55,84 @@ def term_program_of_study_area_changed_prev_term(
     return _changed_prev_term(df, col=area_col, **kwargs)
 
 
+def _summary_aggregation_named_aggs(
+    df: pd.DataFrame, cols: CourseInputColumns
+) -> dict[str, pd.NamedAgg]:
+    """
+    Build groupby NamedAgg kwargs only for columns present on ``df``.
+
+    Edvise institutions may omit optional raw fields (e.g. ``department``) and thus
+    lack derived ``course_subject_area``; PDP-style frames always include CIP.
+    """
+    kw: dict[str, pd.NamedAgg] = {}
+
+    def _add(key: str, named: pd.NamedAgg) -> None:
+        if named.column in df.columns:
+            kw[key] = named
+
+    if "course_id" in df.columns:
+        _add("num_courses", num_courses_col_agg(col="course_id"))
+        _add("course_ids", course_ids_col_agg())
+        _add("course_id_nunique", course_id_nunique_col_agg())
+    if "course_passed" in df.columns:
+        _add("num_courses_passed", num_courses_passed_col_agg())
+    if "course_completed" in df.columns:
+        _add("num_courses_completed", num_courses_completed_col_agg())
+    if cols.number_of_credits_attempted in df.columns:
+        _add(
+            "num_credits_attempted",
+            num_credits_attempted_col_agg(col=cols.number_of_credits_attempted),
+        )
+    if cols.number_of_credits_earned in df.columns:
+        _add(
+            "num_credits_earned",
+            num_credits_earned_col_agg(col=cols.number_of_credits_earned),
+        )
+    if cols.course_cip and cols.course_cip in df.columns:
+        _add("course_subjects", course_subjects_col_agg(col=cols.course_cip))
+        _add(
+            "course_subject_nunique",
+            course_subject_nunique_col_agg(col=cols.course_cip),
+        )
+    if "course_subject_area" in df.columns:
+        _add("course_subject_areas", course_subject_areas_col_agg())
+        _add(
+            "course_subject_area_nunique",
+            course_subject_area_nunique_col_agg(),
+        )
+    if "course_level" in df.columns:
+        _add("course_level_mean", course_level_mean_col_agg())
+        _add("course_level_std", course_level_std_col_agg())
+    if "course_grade_numeric" in df.columns:
+        _add(
+            "course_grade_numeric_mean",
+            course_grade_numeric_mean_col_agg(),
+        )
+        _add(
+            "course_grade_numeric_std",
+            course_grade_numeric_std_col_agg(),
+        )
+    for out_name, builder in (
+        (
+            "section_num_students_enrolled_mean",
+            section_num_students_enrolled_mean_col_agg,
+        ),
+        (
+            "section_num_students_enrolled_std",
+            section_num_students_enrolled_std_col_agg,
+        ),
+        ("sections_num_students_enrolled", sections_num_students_enrolled_col_agg),
+        ("sections_num_students_passed", sections_num_students_passed_col_agg),
+        (
+            "sections_num_students_completed",
+            sections_num_students_completed_col_agg,
+        ),
+    ):
+        named = builder()
+        _add(out_name, named)
+    return kw
+
+
 def aggregate_from_course_level_features(
     df: pd.DataFrame,
     *,
@@ -117,33 +195,9 @@ def aggregate_from_course_level_features(
     df_passthrough = df_grped.agg(**p_existing)
     dfs: list[pd.DataFrame] = [df_passthrough]
     if s.summary_aggregations:
-        ag = df_grped.agg(
-            num_courses=num_courses_col_agg(col="course_id"),
-            num_courses_passed=num_courses_passed_col_agg(col="course_passed"),
-            num_courses_completed=num_courses_completed_col_agg(col="course_completed"),
-            num_credits_attempted=num_credits_attempted_col_agg(
-                col=cols.number_of_credits_attempted
-            ),
-            num_credits_earned=num_credits_earned_col_agg(
-                col=cols.number_of_credits_earned
-            ),
-            course_ids=course_ids_col_agg(),
-            course_subjects=course_subjects_col_agg(col=cols.course_cip),
-            course_subject_areas=course_subject_areas_col_agg(),
-            course_id_nunique=course_id_nunique_col_agg(),
-            course_subject_nunique=course_subject_nunique_col_agg(col=cols.course_cip),
-            course_subject_area_nunique=course_subject_area_nunique_col_agg(),
-            course_level_mean=course_level_mean_col_agg(),
-            course_level_std=course_level_std_col_agg(),
-            course_grade_numeric_mean=course_grade_numeric_mean_col_agg(),
-            course_grade_numeric_std=course_grade_numeric_std_col_agg(),
-            section_num_students_enrolled_mean=section_num_students_enrolled_mean_col_agg(),
-            section_num_students_enrolled_std=section_num_students_enrolled_std_col_agg(),
-            sections_num_students_enrolled=sections_num_students_enrolled_col_agg(),
-            sections_num_students_passed=sections_num_students_passed_col_agg(),
-            sections_num_students_completed=sections_num_students_completed_col_agg(),
-        )
-        dfs.append(ag)
+        summary_aggs = _summary_aggregation_named_aggs(df, cols)
+        if summary_aggs:
+            dfs.append(df_grped.agg(**summary_aggs))
     if s.dummies:
         dummy_candidates: list[str | None] = [
             cols.course_type,

--- a/src/edvise/feature_generation/student_term.py
+++ b/src/edvise/feature_generation/student_term.py
@@ -309,7 +309,11 @@ def add_features(
             student_term_enrollment_intensity,
             min_num_credits_full_time=min_num_credits_full_time,
         )
-    if s.num_courses_in_program_area and s.program_of_study_area:
+    if (
+        s.num_courses_in_program_area
+        and s.program_of_study_area
+        and "course_subject_areas" in df.columns
+    ):
         batch1["num_courses_in_term_program_of_study_area"] = ft.partial(
             num_courses_in_study_area,
             study_area_col="term_program_of_study_area",

--- a/src/edvise/feature_generation/student_term.py
+++ b/src/edvise/feature_generation/student_term.py
@@ -5,9 +5,16 @@ import typing as t
 import numpy as np
 import pandas as pd
 
-
 from edvise.utils.data_cleaning import convert_to_snake_case
 from . import constants, term, shared
+from .feature_dependencies import (
+    MULTICOL_GRADE_COLUMNS,
+    SECTION_STUDENT_FRACTION_COLUMNS,
+    STUDENT_RATE_VS_SECTION_COLUMNS,
+    columns_present,
+    enable_when,
+    filter_named_aggs,
+)
 from .column_names import (
     CourseInputColumns,
     PDP_COURSE_INPUT_COLUMNS,
@@ -61,8 +68,7 @@ def _summary_aggregation_named_aggs(
     """
     Build groupby NamedAgg kwargs only for columns present on ``df``.
 
-    Edvise institutions may omit optional raw fields (e.g. ``department``) and thus
-    lack derived ``course_subject_area``; PDP-style frames always include CIP.
+    Each aggregation is included when its source column exists; no per-school branching.
     """
     kw: dict[str, pd.NamedAgg] = {}
 
@@ -128,9 +134,8 @@ def _summary_aggregation_named_aggs(
             sections_num_students_completed_col_agg,
         ),
     ):
-        named = builder()
-        _add(out_name, named)
-    return kw
+        _add(out_name, builder())
+    return filter_named_aggs(df, kw)
 
 
 def aggregate_from_course_level_features(
@@ -244,7 +249,7 @@ def aggregate_from_course_level_features(
             )
             dfs.append(df_val_equals)
             dfs.append(df_dummy_equals)
-    if s.multicol_grade:
+    if enable_when(s.multicol_grade, df, *MULTICOL_GRADE_COLUMNS):
         df_grade_aggs = multicol_grade_aggs_by_group(
             df, min_passing_grade=min_passing_grade, grp_cols=student_term_id_cols
         )
@@ -301,9 +306,11 @@ def add_features(
         batch1["term_is_while_student_enrolled_at_other_inst"] = (
             term_is_while_student_enrolled_at_other_inst
         )
-    if s.program_of_study_area:
+    if enable_when(s.program_of_study_area, df, cols.term_program_of_study):
         batch1["term_program_of_study_area"] = term_program_of_study_area
-    if s.credit_fraction_and_intensity:
+    if enable_when(
+        s.credit_fraction_and_intensity, df, "num_credits_attempted", "num_credits_earned"
+    ):
         batch1["frac_credits_earned"] = shared.frac_credits_earned
         batch1["student_term_enrollment_intensity"] = ft.partial(
             student_term_enrollment_intensity,
@@ -339,7 +346,7 @@ def add_features(
             for nc_col, fc_col in num_frac_courses_cols
         }
         out = out.assign(**frac_d) if frac_d else out
-    if s.section_student_fractions:
+    if enable_when(s.section_student_fractions, out, *SECTION_STUDENT_FRACTION_COLUMNS):
         out = out.assign(
             **{
                 "frac_sections_students_passed": ft.partial(
@@ -352,7 +359,9 @@ def add_features(
                 ),
             }
         )
-    if s.student_rate_vs_section_fractions:
+    if enable_when(
+        s.student_rate_vs_section_fractions, out, *STUDENT_RATE_VS_SECTION_COLUMNS
+    ):
         out = out.assign(
             **{
                 "student_pass_rate_above_sections_avg": ft.partial(
@@ -367,19 +376,19 @@ def add_features(
                 ),
             }
         )
-    if s.program_change_from_prior_term:
-        out = out.assign(
-            **{
-                "term_program_of_study_changed_prev_term": ft.partial(
-                    term_program_of_study_changed_prev_term,
-                    student_id_cols=[cols.student_id],
-                ),
-                "term_program_of_study_area_changed_prev_term": ft.partial(
-                    term_program_of_study_area_changed_prev_term,
-                    student_id_cols=[cols.student_id],
-                ),
-            }
-        )
+    if s.program_change_from_prior_term and cols.term_program_of_study in out.columns:
+        change_assigns: dict[str, t.Any] = {
+            "term_program_of_study_changed_prev_term": ft.partial(
+                term_program_of_study_changed_prev_term,
+                student_id_cols=[cols.student_id],
+            ),
+        }
+        if "term_program_of_study_area" in out.columns:
+            change_assigns["term_program_of_study_area_changed_prev_term"] = ft.partial(
+                term_program_of_study_area_changed_prev_term,
+                student_id_cols=[cols.student_id],
+            )
+        out = out.assign(**change_assigns)
     return out
 
 
@@ -701,34 +710,45 @@ def multicol_grade_aggs_by_group(
     grade_numeric_col: str = "course_grade_numeric",
     section_grade_numeric_col: str = "section_course_grade_numeric_mean",
 ) -> pd.DataFrame:
+    base_cols = [c for c in grp_cols if c in df.columns]
+    work_cols = [
+        c
+        for c in (grade_col, grade_numeric_col, section_grade_numeric_col)
+        if c in df.columns
+    ]
+    if not columns_present(df, grade_col, grade_numeric_col):
+        return df.loc[:, base_cols].drop_duplicates().reset_index(drop=True)
+
+    assigns: dict[str, t.Any] = {
+        "course_grade_is_failing_or_withdrawal": ft.partial(
+            _course_grade_is_failing_or_withdrawal,
+            min_passing_grade=min_passing_grade,
+            grade_col=grade_col,
+            grade_numeric_col=grade_numeric_col,
+        ),
+    }
+    aggs: dict[str, tuple[str, str]] = {
+        "num_courses_grade_is_failing_or_withdrawal": (
+            "course_grade_is_failing_or_withdrawal",
+            "sum",
+        ),
+    }
+    if section_grade_numeric_col in df.columns:
+        assigns["course_grade_above_section_avg"] = ft.partial(
+            _course_grade_above_section_avg,
+            grade_numeric_col=grade_numeric_col,
+            section_grade_numeric_col=section_grade_numeric_col,
+        )
+        aggs["num_courses_grade_above_section_avg"] = (
+            "course_grade_above_section_avg",
+            "sum",
+        )
+
     return (
-        df.loc[:, grp_cols + [grade_col, grade_numeric_col, section_grade_numeric_col]]
-        # compute intermediate column values all at once, which is efficient
-        .assign(
-            course_grade_is_failing_or_withdrawal=ft.partial(
-                _course_grade_is_failing_or_withdrawal,
-                min_passing_grade=min_passing_grade,
-                grade_col=grade_col,
-                grade_numeric_col=grade_numeric_col,
-            ),
-            course_grade_above_section_avg=ft.partial(
-                _course_grade_above_section_avg,
-                grade_numeric_col=grade_numeric_col,
-                section_grade_numeric_col=section_grade_numeric_col,
-            ),
-        )
+        df.loc[:, base_cols + work_cols]
+        .assign(**assigns)
         .groupby(by=grp_cols, observed=True, as_index=False)
-        # so that we can efficiently aggregate those intermediate values per group
-        .agg(
-            num_courses_grade_is_failing_or_withdrawal=(
-                "course_grade_is_failing_or_withdrawal",
-                "sum",
-            ),
-            num_courses_grade_above_section_avg=(
-                "course_grade_above_section_avg",
-                "sum",
-            ),
-        )
+        .agg(**aggs)
     )
 
 

--- a/tests/feature_generation/test_feature_dependencies.py
+++ b/tests/feature_generation/test_feature_dependencies.py
@@ -1,0 +1,130 @@
+import pandas as pd
+
+from edvise.feature_generation.column_names import (
+    ES_COURSE_INPUT_COLUMNS,
+    CourseFeatureSpec,
+    SectionFeatureSpec,
+)
+from edvise.feature_generation.feature_dependencies import (
+    MULTICOL_GRADE_COLUMNS,
+    columns_present,
+    enable_when,
+    multicol_grade_enabled,
+)
+from edvise.feature_generation.feature_resolution import (
+    resolve_course_feature_spec,
+    resolve_section_feature_spec,
+    resolve_student_term_aggregate_spec,
+)
+from edvise.feature_generation import student_term
+
+
+def test_multicol_grade_disabled_without_section_id():
+    df = pd.DataFrame(
+        {
+            "course_prefix": ["MATH"],
+            "course_number": ["101"],
+            "grade": ["A"],
+        }
+    )
+    course = resolve_course_feature_spec(df, ES_COURSE_INPUT_COLUMNS)
+    section = resolve_section_feature_spec(df, ES_COURSE_INPUT_COLUMNS)
+    agg = resolve_student_term_aggregate_spec(
+        df,
+        ES_COURSE_INPUT_COLUMNS,
+        course_flags=course,
+        section_flags=section,
+    )
+    assert course.course_grade_numeric is True
+    assert section.section_course_grade_numeric_mean is False
+    assert agg.multicol_grade is False
+
+
+def test_multicol_grade_enabled_with_full_section_stack():
+    df = pd.DataFrame(
+        {
+            "course_prefix": ["MATH"],
+            "course_number": ["101"],
+            "grade": ["A"],
+            "course_section_id": ["S1"],
+        }
+    )
+    course = resolve_course_feature_spec(df, ES_COURSE_INPUT_COLUMNS)
+    section = resolve_section_feature_spec(df, ES_COURSE_INPUT_COLUMNS)
+    agg = resolve_student_term_aggregate_spec(
+        df,
+        ES_COURSE_INPUT_COLUMNS,
+        course_flags=course,
+        section_flags=section,
+    )
+    assert multicol_grade_enabled(course_flags=course, section_flags=section) is True
+    assert agg.multicol_grade is True
+
+
+def test_aggregate_skips_missing_department_columns():
+    df = pd.DataFrame(
+        {
+            "learner_id": ["s1", "s1"],
+            "term_id": ["t1", "t1"],
+            "institution_id": ["i1", "i1"],
+            "academic_year": ["20-21", "20-21"],
+            "academic_term": ["FALL", "FALL"],
+            "term_start_dt": pd.to_datetime(["2020-09-01", "2020-09-01"]),
+            "term_rank": [1, 1],
+            "term_rank_core": [1, 1],
+            "term_rank_noncore": [1, 1],
+            "term_is_core": [True, True],
+            "term_is_noncore": [False, False],
+            "term_in_peak_covid": [False, False],
+            "term_degree": ["A.S.", "A.S."],
+            "course_id": ["c1", "c2"],
+            "course_passed": [True, True],
+            "course_completed": [True, True],
+            "course_credits_attempted": [3.0, 3.0],
+            "course_credits_earned": [3.0, 3.0],
+        }
+    )
+    out = student_term.aggregate_from_course_level_features(
+        df,
+        student_term_id_cols=["learner_id", "term_id"],
+        cols=ES_COURSE_INPUT_COLUMNS,
+    )
+    assert "course_subject_areas" not in out.columns
+    assert "num_courses" in out.columns
+
+
+def test_multicol_grade_aggs_without_section_mean_column():
+    df = pd.DataFrame(
+        {
+            "learner_id": ["s1"],
+            "term_id": ["t1"],
+            "grade": ["F"],
+            "course_grade_numeric": [0.0],
+        }
+    )
+    out = student_term.multicol_grade_aggs_by_group(
+        df,
+        min_passing_grade=1.0,
+        grp_cols=["learner_id", "term_id"],
+    )
+    assert "num_courses_grade_is_failing_or_withdrawal" in out.columns
+    assert "num_courses_grade_above_section_avg" not in out.columns
+
+
+def test_enable_when_requires_all_columns():
+    df = pd.DataFrame({"a": [1]})
+    assert columns_present(df, "a") is True
+    assert columns_present(df, "a", "b") is False
+    assert enable_when(True, df, "a") is True
+    assert enable_when(True, df, "a", "b") is False
+    assert enable_when(False, df, "a") is False
+
+
+def test_multicol_grade_columns_constant_matches_resolution():
+    assert MULTICOL_GRADE_COLUMNS == (
+        "grade",
+        "course_grade_numeric",
+        "section_course_grade_numeric_mean",
+    )
+    assert CourseFeatureSpec.all().course_grade
+    assert SectionFeatureSpec.all().section_course_grade_numeric_mean


### PR DESCRIPTION
## Description

Upstream specs decide what to generate from raw columns; downstream steps double-check those columns exist before aggregating — so sparse ES datasets skip optional features instead of crashing.

## Asana Task
(https://app.asana.com/1/6325821815997/project/1208486153653829/task/1215812610764153)

## Deployment Readiness\*

### Testing

Describe or check:

- [x] Created or updated unit, feature, and/or integration tests  
- [x] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [x]  No special deployment steps required

### Rollback Plan

Describe or check:

- [x]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional