### PR TITLE
feat(genai): entity kind backcompat for profiling templates

### DIFF
--- a/configs/genai_mapping/inputs-TEMPLATE.toml
+++ b/configs/genai_mapping/inputs-TEMPLATE.toml
@@ -19,6 +19,14 @@ course = "genai_mapping/onboard/FILE_NAME_courses.csv"
 #   "genai_mapping/onboard/FILE_NAME_courses_2014_2025.csv",
 # ]
 
+# Optional: map logical dataset names to semantic templates when the key is not
+# exactly student / course / semester / degree (backwards compatible — omit entirely
+# when keys already use the canonical names).
+#
+# [datasets.entity_kind]
+# registration = "course"
+# degree_awards = "degree"
+
 # Uncomment when wiring the execute pipeline (onboard-only can omit this block):
 # [datasets.execute_files]
 # student = "genai_mapping/execute/FILE_NAME_students.csv"

--- a/src/edvise/configs/genai.py
+++ b/src/edvise/configs/genai.py
@@ -49,6 +49,13 @@ class DatasetConfig(StrictBaseModel):
     files: List[str] = Field(..., min_length=1)
     primary_keys: Optional[List[str]] = Field(default=None, min_length=1)
     student_id_alias: Optional[str] = None
+    entity_kind: Optional[str] = Field(
+        default=None,
+        description=(
+            "Semantic template for profiling (student, course, semester, degree). "
+            "When unset, the dataset key name and built-in aliases are used."
+        ),
+    )
 
 
 class SchoolMappingConfig(StrictBaseModel):
@@ -88,6 +95,14 @@ class IdentityAgentDatasets(StrictBaseModel):
     execute_files: Optional[
         Annotated[Dict[str, Union[str, List[str]]], Field(min_length=1)]
     ] = None
+    entity_kind: Optional[Dict[str, str]] = Field(
+        default=None,
+        description=(
+            "Optional map of logical dataset name → semantic kind "
+            "(student, course, semester, degree). Backwards compatible: omit to use "
+            "dataset key names and built-in aliases (registration → course, etc.)."
+        ),
+    )
 
     @field_validator("onboard_files", "execute_files", mode="before")
     @classmethod
@@ -153,6 +168,7 @@ class IdentityAgentInputsConfig(StrictBaseModel):
                 )
             merged_files = dict(ds.execute_files)
 
+        kind_map = dict(ds.entity_kind or {})
         datasets: Dict[str, DatasetConfig] = {}
         for name, spec in merged_files.items():
             paths: List[str] = [spec] if isinstance(spec, str) else list(spec)
@@ -160,7 +176,11 @@ class IdentityAgentInputsConfig(StrictBaseModel):
                 raise ValueError(
                     f"datasets.{pipeline_mode}_files[{name!r}] must list at least one path"
                 )
-            datasets[name] = DatasetConfig(files=paths, primary_keys=None)
+            datasets[name] = DatasetConfig(
+                files=paths,
+                primary_keys=None,
+                entity_kind=kind_map.get(name),
+            )
         rid = resolve_onboard_run_id(onboard_run_id, create_if_missing=False)
         pv = coerce_pipeline_version(pipeline_version)
         return SchoolMappingConfig(

--- a/src/edvise/genai/mapping/identity_agent/column_roles/prompt.py
+++ b/src/edvise/genai/mapping/identity_agent/column_roles/prompt.py
@@ -73,11 +73,18 @@ def build_column_roles_user_message(
     institution_id: str,
     dataset: str,
     raw_table_profile: RawTableProfile,
+    *,
+    entity_kind: str | None = None,
 ) -> str:
+    from edvise.genai.mapping.identity_agent.profiling.entity_kind import (
+        resolve_entity_kind,
+    )
+
+    kind_hint = resolve_entity_kind(dataset, configured_kind=entity_kind)
     payload = {
         "institution_id": institution_id,
         "dataset": dataset,
-        "dataset_kind_hint": dataset,
+        "dataset_kind_hint": kind_hint,
         "row_count": raw_table_profile.row_count,
         "columns": _column_summaries_for_prompt(raw_table_profile),
     }

--- a/src/edvise/genai/mapping/identity_agent/column_roles/runner.py
+++ b/src/edvise/genai/mapping/identity_agent/column_roles/runner.py
@@ -43,6 +43,7 @@ def run_column_roles_for_dataset(
     df: pd.DataFrame,
     llm_complete: Callable[[str, str], str],
     cleaning: CleaningConfig | None = None,
+    entity_kind: str | None = None,
 ) -> ColumnRolesResult:
     """
     Classify columns via LLM using a raw table profile, then apply deterministic fallbacks.
@@ -54,7 +55,12 @@ def run_column_roles_for_dataset(
         dataset=dataset,
         cleaning=cleaning,
     )
-    user = build_column_roles_user_message(institution_id, dataset, raw_table_profile)
+    user = build_column_roles_user_message(
+        institution_id,
+        dataset,
+        raw_table_profile,
+        entity_kind=entity_kind,
+    )
     expected_columns = [c.name for c in raw_table_profile.columns]
 
     def _parse(raw: str) -> ColumnRolesResult:
@@ -92,6 +98,7 @@ def run_column_roles_for_institution(
     """Run :func:`run_column_roles_for_dataset` for each configured dataset."""
     results: dict[str, ColumnRolesResult] = {}
     for name in school.datasets.keys():
+        ds_cfg = school.datasets[name]
         df = load_school_dataset_dataframe(school, name)
         results[name] = run_column_roles_for_dataset(
             institution_id=institution_id,
@@ -99,6 +106,7 @@ def run_column_roles_for_institution(
             df=df,
             llm_complete=llm_complete,
             cleaning=school.cleaning,
+            entity_kind=ds_cfg.entity_kind,
         )
     return results
 

--- a/src/edvise/genai/mapping/identity_agent/grain_inference/run_by_dataset.py
+++ b/src/edvise/genai/mapping/identity_agent/grain_inference/run_by_dataset.py
@@ -57,6 +57,7 @@ def build_identity_profiling_run_by_dataset(
 
     for name in school.datasets.keys():
         df = load_school_dataset_dataframe(school, name)
+        ds_cfg = school.datasets[name]
         column_roles = (
             column_roles_by_dataset.get(name) if column_roles_by_dataset else None
         )
@@ -66,6 +67,7 @@ def build_identity_profiling_run_by_dataset(
             dataset=name,
             cleaning=cleaning,
             column_roles=column_roles,
+            entity_kind=ds_cfg.entity_kind,
         )
         key_profile = kp_result.key_profile
         rtp = kp_result.raw_table_profile

--- a/src/edvise/genai/mapping/identity_agent/profiling/candidate_keys.py
+++ b/src/edvise/genai/mapping/identity_agent/profiling/candidate_keys.py
@@ -333,11 +333,17 @@ def _merge_semantic_and_statistical_candidates(
     dataset: str,
     statistical: list[CandidateKey],
     column_roles: ColumnRolesResult,
+    *,
+    entity_kind: str | None = None,
 ) -> list[CandidateKey]:
     """
     Guarantee semantic grain keys appear in the candidate list (not truncated by top-k search).
     """
-    semantic_sets = build_semantic_key_column_sets(dataset, column_roles)
+    semantic_sets = build_semantic_key_column_sets(
+        dataset,
+        column_roles,
+        entity_kind=entity_kind,
+    )
     merged: list[CandidateKey] = []
     seen: set[frozenset[str]] = set()
 
@@ -431,6 +437,7 @@ def profile_candidate_keys(
     *,
     cleaning: CleaningConfig | None = None,
     column_roles: ColumnRolesResult | None = None,
+    entity_kind: str | None = None,
 ) -> KeyProfileResult:
     """
     Deterministic key profiler. Runs raw column profiling, then detects candidate
@@ -456,6 +463,8 @@ def profile_candidate_keys(
         cleaning: Optional per-school cleaning config (e.g. from ``SchoolMappingConfig.cleaning``).
         column_roles: Optional ColumnRolesAgent output; when set, semantic grain keys are
             profiled first and guaranteed in the candidate list.
+        entity_kind: Optional semantic template override (``DatasetConfig.entity_kind``).
+            When unset, the dataset name and built-in aliases select the template.
 
     Returns:
         KeyProfileResult with raw column stats and per-candidate-key stats
@@ -497,6 +506,7 @@ def profile_candidate_keys(
             dataset,
             candidate_keys,
             column_roles,
+            entity_kind=entity_kind,
         )
         for warning in column_roles.profiler_warnings:
             logger.warning("ColumnRoles: %s", warning)

--- a/src/edvise/genai/mapping/identity_agent/profiling/entity_kind.py
+++ b/src/edvise/genai/mapping/identity_agent/profiling/entity_kind.py
@@ -1,0 +1,63 @@
+"""Resolve semantic entity kind for profiling (decoupled from inputs.toml dataset keys)."""
+
+from __future__ import annotations
+
+CANONICAL_ENTITY_KINDS: frozenset[str] = frozenset(
+    {"student", "course", "semester", "degree"}
+)
+
+# Backwards-compatible aliases when ``entity_kind`` is not set explicitly in inputs.toml.
+ENTITY_KIND_ALIASES: dict[str, str] = {
+    "cohort": "student",
+    "students": "student",
+    "registration": "course",
+    "registrations": "course",
+    "enrollment": "course",
+    "enrollments": "course",
+    "class": "course",
+    "classes": "course",
+    "section": "course",
+    "sections": "course",
+    "terms": "semester",
+    "term_summary": "semester",
+    "student_term": "semester",
+    "student_terms": "semester",
+    "award": "degree",
+    "awards": "degree",
+    "degrees": "degree",
+    "conferral": "degree",
+    "conferrals": "degree",
+}
+
+
+def resolve_entity_kind(
+    dataset_name: str,
+    *,
+    configured_kind: str | None = None,
+) -> str:
+    """
+    Map a logical dataset name to a semantic template kind.
+
+    Priority:
+    1. Explicit ``configured_kind`` from ``DatasetConfig.entity_kind`` / inputs.toml
+    2. Exact canonical kind match on the dataset name (``student``, ``course``, …)
+    3. Built-in alias table (``registration`` → ``course``, etc.)
+    4. Lowercased dataset name unchanged (unknown template)
+    """
+    if configured_kind is not None and str(configured_kind).strip():
+        key = str(configured_kind).strip().lower()
+        if key in CANONICAL_ENTITY_KINDS:
+            return key
+        return ENTITY_KIND_ALIASES.get(key, key)
+
+    key = dataset_name.strip().lower()
+    if key in CANONICAL_ENTITY_KINDS:
+        return key
+    return ENTITY_KIND_ALIASES.get(key, key)
+
+
+__all__ = [
+    "CANONICAL_ENTITY_KINDS",
+    "ENTITY_KIND_ALIASES",
+    "resolve_entity_kind",
+]

--- a/src/edvise/genai/mapping/identity_agent/profiling/semantic_keys.py
+++ b/src/edvise/genai/mapping/identity_agent/profiling/semantic_keys.py
@@ -13,6 +13,8 @@ from edvise.genai.mapping.identity_agent.column_roles.schemas import (
     ColumnRolesResult,
 )
 
+from .entity_kind import resolve_entity_kind
+
 logger = logging.getLogger(__name__)
 
 
@@ -25,12 +27,73 @@ def _course_id_columns(roles: ColumnRolesResult) -> list[str]:
     return roles.columns_with_role(ColumnRole.COURSE_ID)
 
 
+def _append_student_keys(
+    keys: list[list[str]],
+    *,
+    learner: str,
+    program: str | None,
+    major: str | None,
+    cohort: str | None,
+) -> None:
+    keys.append([learner])
+    for extra in (program, major, cohort):
+        if extra:
+            keys.append([learner, extra])
+    if program and major:
+        keys.append([learner, program, major])
+
+
+def _append_degree_keys(
+    keys: list[list[str]],
+    *,
+    learner: str | None,
+    term: str | None,
+    program: str | None,
+    major: str | None,
+) -> None:
+    if learner and term:
+        keys.append([learner, term])
+    if learner and program and term:
+        keys.append([learner, program, term])
+    if learner and program:
+        keys.append([learner, program])
+    if learner and program and major:
+        keys.append([learner, program, major])
+    if learner and major and term:
+        keys.append([learner, major, term])
+    if learner:
+        keys.append([learner])
+    elif term:
+        keys.append([term])
+
+
+def _append_role_driven_fallback_keys(
+    keys: list[list[str]],
+    *,
+    learner: str | None,
+    term: str | None,
+) -> None:
+    """Unknown kinds: seed from roles when no template matched."""
+    if learner and term:
+        keys.append([learner, term])
+    elif term:
+        keys.append([term])
+    elif learner:
+        keys.append([learner])
+
+
 def build_semantic_key_column_sets(
     dataset: str,
     roles: ColumnRolesResult,
+    *,
+    entity_kind: str | None = None,
 ) -> list[list[str]]:
     """
     Return ordered semantic key column lists to profile before combinatorial search.
+
+    ``entity_kind`` (from ``DatasetConfig`` / inputs.toml) selects the template;
+    when omitted, :func:`resolve_entity_kind` uses the dataset name and aliases
+    (``student`` / ``course`` / ``semester`` keys behave as before).
 
     Keys are deduplicated; order is stable (base grains first, then widenings).
     """
@@ -42,16 +105,17 @@ def build_semantic_key_column_sets(
     cohort = _first(roles.columns_with_role(ColumnRole.COHORT))
 
     keys: list[list[str]] = []
-    kind = dataset.strip().lower()
+    kind = resolve_entity_kind(dataset, configured_kind=entity_kind)
 
     if kind == "student":
         if learner:
-            keys.append([learner])
-            for extra in (program, major, cohort):
-                if extra:
-                    keys.append([learner, extra])
-            if program and major:
-                keys.append([learner, program, major])
+            _append_student_keys(
+                keys,
+                learner=learner,
+                program=program,
+                major=major,
+                cohort=cohort,
+            )
         else:
             logger.warning(
                 "semantic_keys: student dataset %s missing learner_id — no base semantic keys",
@@ -80,13 +144,30 @@ def build_semantic_key_column_sets(
         elif learner:
             keys.append([learner])
 
-    else:
-        if learner:
-            keys.append([learner])
-        logger.info(
-            "semantic_keys: unknown dataset kind %r — using learner-only template if present",
-            dataset,
+    elif kind == "degree":
+        _append_degree_keys(
+            keys,
+            learner=learner,
+            term=term,
+            program=program,
+            major=major,
         )
+
+    else:
+        _append_role_driven_fallback_keys(keys, learner=learner, term=term)
+        if keys:
+            logger.info(
+                "semantic_keys: unknown entity kind %r for dataset %s — role-driven seeds %s",
+                kind,
+                dataset,
+                keys,
+            )
+        else:
+            logger.info(
+                "semantic_keys: unknown entity kind %r for dataset %s — no semantic keys",
+                kind,
+                dataset,
+            )
 
     return _dedupe_key_lists(keys)
 

--- a/tests/configs/test_identity_agent_inputs_config.py
+++ b/tests/configs/test_identity_agent_inputs_config.py
@@ -364,6 +364,31 @@ def test_to_school_mapping_config_onboard_execute_files_are_separate_tables(
     assert execute_school.datasets["course"].files == ["execute_course.csv"]
 
 
+def test_to_school_mapping_config_entity_kind_from_toml(tmp_path: Path) -> None:
+    p = tmp_path / "inputs.toml"
+    p.write_text(
+        textwrap.dedent(
+            """
+            institution_id = "synthetic_univ_alpha"
+
+            [datasets.onboard_files]
+            registration = "enrollments.csv"
+            student = "students.csv"
+
+            [datasets.entity_kind]
+            registration = "course"
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+    raw = IdentityAgentInputsConfig.model_validate(from_toml_file(str(p)))
+    school = raw.to_school_mapping_config(
+        uc_catalog="dev_sst_02", pipeline_mode="onboard"
+    )
+    assert school.datasets["student"].entity_kind is None
+    assert school.datasets["registration"].entity_kind == "course"
+
+
 def test_to_school_mapping_config_onboard_run_id_from_env(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/genai/mapping/identity_agent/test_entity_kind.py
+++ b/tests/genai/mapping/identity_agent/test_entity_kind.py
@@ -1,0 +1,100 @@
+"""Tests for entity kind resolution and backwards-compatible semantic templates."""
+
+from edvise.genai.mapping.identity_agent.column_roles.schemas import (
+    ColumnRole,
+    ColumnRoleAssignment,
+    ColumnRolesResult,
+)
+from edvise.genai.mapping.identity_agent.profiling.entity_kind import (
+    resolve_entity_kind,
+)
+from edvise.genai.mapping.identity_agent.profiling.semantic_keys import (
+    build_semantic_key_column_sets,
+)
+
+
+def _course_roles() -> ColumnRolesResult:
+    return ColumnRolesResult(
+        institution_id="test_u",
+        dataset="registration",
+        assignments=[
+            ColumnRoleAssignment(
+                column="student_id",
+                role=ColumnRole.LEARNER_ID,
+                confidence=0.99,
+            ),
+            ColumnRoleAssignment(
+                column="semester",
+                role=ColumnRole.TERM,
+                confidence=0.99,
+            ),
+            ColumnRoleAssignment(
+                column="course_number",
+                role=ColumnRole.COURSE_ID,
+                confidence=0.8,
+            ),
+            ColumnRoleAssignment(
+                column="course_section",
+                role=ColumnRole.COURSE_ID,
+                confidence=0.85,
+            ),
+        ],
+    )
+
+
+def test_resolve_entity_kind_backwards_compat_canonical_names():
+    assert resolve_entity_kind("student") == "student"
+    assert resolve_entity_kind("course") == "course"
+    assert resolve_entity_kind("semester") == "semester"
+
+
+def test_resolve_entity_kind_builtin_aliases():
+    assert resolve_entity_kind("registration") == "course"
+    assert resolve_entity_kind("degrees") == "degree"
+
+
+def test_resolve_entity_kind_explicit_override():
+    assert resolve_entity_kind("my_enrollments", configured_kind="course") == "course"
+    assert resolve_entity_kind("student", configured_kind="semester") == "semester"
+
+
+def test_build_semantic_keys_registration_alias_uses_course_template():
+    roles = _course_roles()
+    keys = build_semantic_key_column_sets("registration", roles)
+    assert keys[0] == [
+        "student_id",
+        "course_number",
+        "course_section",
+        "semester",
+    ]
+
+
+def test_build_semantic_keys_entity_kind_override_on_custom_name():
+    roles = _course_roles()
+    keys = build_semantic_key_column_sets(
+        "my_file",
+        roles,
+        entity_kind="course",
+    )
+    assert keys[0] == [
+        "student_id",
+        "course_number",
+        "course_section",
+        "semester",
+    ]
+
+
+def test_build_semantic_keys_unknown_uses_role_driven_fallback():
+    roles = ColumnRolesResult(
+        institution_id="test_u",
+        dataset="term_calendar",
+        assignments=[
+            ColumnRoleAssignment(
+                column="term_code",
+                role=ColumnRole.TERM,
+                confidence=0.95,
+            ),
+        ],
+    )
+    keys = build_semantic_key_column_sets("term_calendar", roles)
+    assert keys == [["term_code"]]


### PR DESCRIPTION
## Summary
- Decouples semantic profiling templates from logical `inputs.toml` dataset keys via optional `[datasets.entity_kind]` and built-in aliases (`registration` → `course`, etc.)
- Threads resolved kind through column roles (Haiku `dataset_kind_hint`) and KeyProfiler semantic seeds
- Adds `degree` template and role-driven fallback for unknown kinds
- **Backwards compatible:** existing `student` / `course` / `semester` keys behave unchanged with no config edits

Stacked on #169 (`feature/semantic-grain-profiling`). Retarget to `develop` after that merges.

## Test plan
- [x] `uv run pytest tests/genai/mapping/identity_agent/test_entity_kind.py`
- [x] `uv run pytest tests/genai/mapping/identity_agent/test_column_roles.py`
- [x] `uv run pytest tests/configs/test_identity_agent_inputs_config.py`


Made with [Cursor](https://cursor.com)