### PR TITLE
feat: exclude students linked to training cohorts during inference

### DIFF
--- a/src/edvise/scripts/inf_prep.py
+++ b/src/edvise/scripts/inf_prep.py
@@ -24,6 +24,7 @@ from edvise.configs.es import InferenceConfig as ESInferenceConfig
 from edvise.model_prep import cleanup_features as cleanup
 from edvise.dataio.read import read_parquet, read_config
 from edvise.student_selection.filter_inference import (
+    exclude_training_cohort_students,
     filter_inference_term,
     parse_term_filter_param,
 )
@@ -185,6 +186,26 @@ class InferencePrepTask:
         df_selected_terms = filter_inference_term(df_labeled, term_list=inf_terms)
 
         cohort_pair = cohort_pair_columns(df_selected_terms)
+        training_cohorts = (
+            self.cfg.modeling.training.cohort
+            if self.cfg.modeling and self.cfg.modeling.training
+            else None
+        )
+        if training_cohorts:
+            if cohort_pair is not None:
+                cy, ct = cohort_pair
+                df_selected_terms = exclude_training_cohort_students(
+                    df_selected_terms,
+                    training_cohorts=training_cohorts,
+                    cohort_term_column=ct,
+                    cohort_column=cy,
+                )
+            else:
+                LOGGER.warning(
+                    "Training cohorts configured but cohort columns not found; "
+                    "skipping stop-out exclusion."
+                )
+
         if cohort_pair is not None:
             cy, ct = cohort_pair
             cohort_counts = (

--- a/src/edvise/scripts/model_prep.py
+++ b/src/edvise/scripts/model_prep.py
@@ -254,7 +254,7 @@ class ModelPrepTask:
                 logging.info("Updating training cohorts in config")
 
                 training_cohorts = (
-                    df_labeled[[cy, ct]]
+                    df_labeled[[ct, cy]]
                     .dropna()
                     .astype(str)
                     .agg(" ".join, axis=1)
@@ -267,12 +267,12 @@ class ModelPrepTask:
 
                 def _cohort_sort_key(x: str) -> tuple[int, int]:
                     parts = x.split()
-                    year_part = parts[0].split("-")[0] if parts else "0"
+                    term_key = parts[0].lower() if parts else ""
+                    year_part = parts[1].split("-")[0] if len(parts) > 1 else "0"
                     try:
                         y = int(year_part)
                     except ValueError:
                         y = 0
-                    term_key = parts[1].lower() if len(parts) > 1 else ""
                     return (y, term_order.get(term_key, 99))
 
                 training_cohorts = sorted(training_cohorts, key=_cohort_sort_key)

--- a/src/edvise/student_selection/filter_inference.py
+++ b/src/edvise/student_selection/filter_inference.py
@@ -30,11 +30,7 @@ def parse_term_filter_param(value: t.Optional[str]) -> t.Optional[list[str]]:
 
 
 def _normalize_label_list(labels: list[str]) -> list[str]:
-    return [
-        label.strip().lower()
-        for label in labels
-        if label and str(label).strip()
-    ]
+    return [label.strip().lower() for label in labels if label and str(label).strip()]
 
 
 def _joined_labels(

--- a/src/edvise/student_selection/filter_inference.py
+++ b/src/edvise/student_selection/filter_inference.py
@@ -29,6 +29,26 @@ def parse_term_filter_param(value: t.Optional[str]) -> t.Optional[list[str]]:
     return labels
 
 
+def _normalize_label_list(labels: list[str]) -> list[str]:
+    return [
+        label.strip().lower()
+        for label in labels
+        if label and str(label).strip()
+    ]
+
+
+def _joined_labels(
+    df: pd.DataFrame,
+    first_column: str,
+    second_column: str,
+) -> pd.Series:
+    return (
+        df[first_column].astype(str).str.lower()
+        + " "
+        + df[second_column].astype(str).str.lower()
+    )
+
+
 def _filter_by_joined_columns(
     df: pd.DataFrame,
     selection_list: list[str],
@@ -53,11 +73,7 @@ def _filter_by_joined_columns(
         ValueError: If selection_list has no non-empty labels, or if filtering results in empty DataFrame.
     """
     # Normalize labels to lowercase so matching is case-insensitive
-    selection_list_normalized = [
-        label.strip().lower()
-        for label in selection_list
-        if label and str(label).strip()
-    ]
+    selection_list_normalized = _normalize_label_list(selection_list)
     if not selection_list_normalized:
         raise ValueError(
             f"{selection_type}_list had no non-empty {selection_type} labels."
@@ -65,11 +81,7 @@ def _filter_by_joined_columns(
 
     # Combine columns and normalize to lowercase
     temp_column = f"{selection_type}_selection"
-    df[temp_column] = (
-        df[first_column].astype(str).str.lower()
-        + " "
-        + df[second_column].astype(str).str.lower()
-    )
+    df[temp_column] = _joined_labels(df, first_column, second_column)
 
     # Filter to only the specified values
     df_filtered = df[df[temp_column].isin(selection_list_normalized)].copy()
@@ -127,6 +139,45 @@ def filter_inference_cohort(
         second_column=cohort_column,
         selection_type="cohorts",
     )
+
+
+def exclude_training_cohort_students(
+    df: pd.DataFrame,
+    training_cohorts: list[str],
+    cohort_term_column: str = "cohort_term",
+    cohort_column: str = "cohort",
+) -> pd.DataFrame:
+    """Exclude students whose entry cohort was used in model training."""
+    training_labels = _normalize_label_list(training_cohorts)
+    if not training_labels:
+        return df
+
+    if cohort_term_column not in df.columns or cohort_column not in df.columns:
+        logging.warning(
+            "Cannot exclude training cohort students: missing columns %r and/or %r.",
+            cohort_term_column,
+            cohort_column,
+        )
+        return df
+
+    labels = _joined_labels(df, cohort_term_column, cohort_column)
+    exclude_mask = labels.isin(training_labels)
+    n_excluded = int(exclude_mask.sum())
+    if n_excluded:
+        logging.info(
+            "Excluded %d stop-out students from training cohorts %s.\n%s",
+            n_excluded,
+            training_cohorts,
+            labels[exclude_mask].value_counts().to_string(),
+        )
+
+    df_filtered = df.loc[~exclude_mask]
+    if df_filtered.empty and not df.empty:
+        raise ValueError(
+            "Excluding training cohort students resulted in empty DataFrame; "
+            f"training_cohorts={training_cohorts!r}."
+        )
+    return df_filtered
 
 
 def filter_inference_term(

--- a/tests/preprocessing/selection/test_inf_filtering.py
+++ b/tests/preprocessing/selection/test_inf_filtering.py
@@ -5,6 +5,7 @@ import pytest
 
 from edvise.student_selection.filter_inference import (
     _filter_by_joined_columns,
+    exclude_training_cohort_students,
     filter_inference_cohort,
     filter_inference_term,
 )
@@ -236,3 +237,58 @@ def test_filter_inference_term_custom_columns():
     )
     assert len(result) == 1
     assert result["id"].iloc[0] == 1
+
+
+# Tests for exclude_training_cohort_students
+def test_exclude_training_cohort_students_removes_stop_outs():
+    df = pd.DataFrame(
+        {
+            "cohort_term": ["FALL", "FALL", "SPRING"],
+            "cohort": ["2023-24", "2024-25", "2024-25"],
+            "id": [1, 2, 3],
+        }
+    )
+    result = exclude_training_cohort_students(
+        df,
+        training_cohorts=["fall 2023-24"],
+    )
+    assert set(result["id"]) == {2, 3}
+
+
+def test_exclude_training_cohort_students_no_training_cohorts():
+    df = pd.DataFrame(
+        {
+            "cohort_term": ["FALL"],
+            "cohort": ["2024-25"],
+            "id": [1],
+        }
+    )
+    result = exclude_training_cohort_students(df, training_cohorts=[])
+    assert len(result) == 1
+
+
+def test_exclude_training_cohort_students_missing_columns_returns_unchanged():
+    df = pd.DataFrame({"id": [1]})
+    result = exclude_training_cohort_students(
+        df,
+        training_cohorts=["fall 2024-25"],
+    )
+    assert len(result) == 1
+
+
+def test_exclude_training_cohort_students_all_excluded_raises():
+    df = pd.DataFrame(
+        {
+            "cohort_term": ["FALL"],
+            "cohort": ["2023-24"],
+            "id": [1],
+        }
+    )
+    with pytest.raises(
+        ValueError,
+        match="Excluding training cohort students resulted in empty DataFrame",
+    ):
+        exclude_training_cohort_students(
+            df,
+            training_cohorts=["fall 2023-24"],
+        )


### PR DESCRIPTION
## Description
Sometimes, a small number of students from previous training cohorts meet the checkpoint in a later inference checkpoint, and we want to exclude them from inference when this happens. Inference should not include students from cohorts that should've been part of the training. These are all most likely for "stop outs," students who started in a training cohort, but probably came back after awhile and met the newest checkpoint.

We want to exclude these training-cohort stop-outs from inference. We now filter out students whose entry cohort matches `modeling.training.cohort`, so prior training cohort members are not included when they meet a later checkpoint.

## Asana Task
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1213791815399128

## Deployment Readiness\*

### Testing

Describe or check:

- [x] Created or updated unit, feature, and/or integration tests  
- [ ] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [x]  No special deployment steps required

### Rollback Plan

Describe or check:

- [x]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional