### PR TITLE
fix: always mapping to fixed values for model name suffixes instead of the inst-specific values

### DIFF
--- a/src/edvise/modeling/registration.py
+++ b/src/edvise/modeling/registration.py
@@ -54,33 +54,44 @@ def _get_attr(obj: t.Any, key: str, default: t.Any = None) -> t.Any:
     return getattr(obj, key, default)
 
 
-def _retention_credential_suffix(raw: str | list[str]) -> str:
+def _retention_credential_suffix(raw: str | list[str]) -> str | None:
     """
     Build the lowercase credential segment for retention model names.
 
-    Single value: ``normalize_degree(...).lower()``. Multiple distinct values:
-    short tokens sorted and joined with underscores; associates + certificate
-    becomes ``associates_and_cert``. Credential strings are typically uppercase
-    in config (e.g. ``ASSOCIATE'S DEGREE``, ``1-2 YEAR CERTIFICATE, LESS THAN
-    ASSOCIATE DEGREE``); labels may contain the word "certificate".
+    Collapses criteria to fixed suffixes via case-insensitive substring matching.
+    Raw criteria strings are never joined into the model name. Empty values yield
+    ``None`` (``all_degrees``).
     """
     if utils_types.is_collection_but_not_string(raw):
-        items = [str(x) for x in raw]
+        items = [str(x).strip() for x in raw if x is not None and str(x).strip()]
+    elif raw is None or not str(raw).strip():
+        items = []
     else:
-        items = [str(raw)]
-    unique = list(dict.fromkeys(normalize_degree(x) for x in items))
-    if len(unique) == 1:
-        return unique[0].lower()
+        items = [str(raw).strip()]
 
-    def _tok(norm: str) -> str:
-        if re.search(r"\bcertificate\b", norm, re.IGNORECASE):
-            return "cert"
-        return "associates" if norm.lower() == "associates" else norm.lower()
+    if not items:
+        return None
 
-    toks = sorted(_tok(n) for n in unique)
-    if toks == ["associates", "cert"]:
+    text = re.sub(r"['\u2019]", "", " ".join(items)).casefold()
+    has_assoc = "assoc" in text
+    has_cert = "cert" in text
+    has_bach = "bach" in text
+
+    if has_assoc and has_bach and has_cert:
+        return "associates_and_bachelors_and_cert"
+    if has_assoc and has_bach:
+        return "associates_and_bachelors"
+    if has_assoc and has_cert:
         return "associates_and_cert"
-    return "_".join(toks)
+    if has_assoc:
+        return "associates"
+    if has_bach:
+        return "bachelors"
+    if has_cert:
+        return "cert"
+    if len(items) == 1:
+        return normalize_degree(items[0]).lower()
+    return None
 
 
 def _retention_credential_from_student_criteria(

--- a/tests/modeling/test_registration.py
+++ b/tests/modeling/test_registration.py
@@ -395,20 +395,35 @@ class TestPDPGetModelName:
         assert result == "retention_into_year_2_associates"
 
     @pytest.mark.parametrize(
-        "second_credential",
+        "second_credential,expected_suffix",
         [
-            "LESS THAN ONE-YEAR CERTIFICATE, LESS THAN ASSOCIATE DEGREE",
-            "ONE TO TWO YEAR CERTIFICATE, LESS THAN ASSOCIATE DEGREE",
-            "1-2 YEAR CERTIFICATE, LESS THAN ASSOCIATE DEGREE",
-            "2-4 YEAR CERTIFICATE, LESS THAN BACHELOR'S DEGREE",
-            "UNDERGRADUATE CERTIFICATE OR DIPLOMA PROGRAM",
+            (
+                "LESS THAN ONE-YEAR CERTIFICATE, LESS THAN ASSOCIATE DEGREE",
+                "associates_and_cert",
+            ),
+            (
+                "ONE TO TWO YEAR CERTIFICATE, LESS THAN ASSOCIATE DEGREE",
+                "associates_and_cert",
+            ),
+            (
+                "1-2 YEAR CERTIFICATE, LESS THAN ASSOCIATE DEGREE",
+                "associates_and_cert",
+            ),
+            (
+                "2-4 YEAR CERTIFICATE, LESS THAN BACHELOR'S DEGREE",
+                "associates_and_bachelors_and_cert",
+            ),
+            (
+                "UNDERGRADUATE CERTIFICATE OR DIPLOMA PROGRAM",
+                "associates_and_cert",
+            ),
         ],
     )
     def test_retention_with_associates_and_certificate_selection(
-        self, second_credential: str
+        self, second_credential: str, expected_suffix: str
     ) -> None:
         """
-        Multi-select ASSOCIATE'S DEGREE + certificate-type credential → associates_and_cert.
+        Multi-select ASSOCIATE'S DEGREE + certificate-type credential.
 
         Raw cohort schema keeps credential_type_sought_year_1 as strings (no remap);
         configs use uppercase PDP-style values as ingested.
@@ -434,7 +449,7 @@ class TestPDPGetModelName:
             checkpoint=checkpoint,
             student_criteria=student_criteria,
         )
-        assert result == "retention_into_year_2_associates_and_cert"
+        assert result == f"retention_into_year_2_{expected_suffix}"
 
     def test_retention_with_bachelor_degree(self):
         """Retention with Bachelor's degree variant"""
@@ -484,7 +499,91 @@ class TestPDPGetModelName:
             checkpoint=checkpoint,
             student_criteria=student_criteria,
         )
-        assert result == "retention_into_year_2_associate"
+        assert result == "retention_into_year_2_associates"
+
+    def test_retention_with_many_edvise_program_types_and_cert(self):
+        """Multiple Edvise program-type labels collapse to associates_and_cert."""
+        target = {"type_": "retention", "max_academic_year": "2024"}
+        checkpoint = {"type_": "first_within_cohort"}
+        student_criteria = {
+            "intended_program_type": [
+                "engineering science_associate",
+                "applied science_associate",
+                "arts_associate",
+                "fine arts_associate",
+                "general studies_associate",
+                "science_associate",
+                "cert",
+                "cert",
+            ],
+        }
+
+        result = pdp_get_model_name(
+            target=target,
+            checkpoint=checkpoint,
+            student_criteria=student_criteria,
+        )
+        assert result == "retention_into_year_2_associates_and_cert"
+
+    def test_retention_with_cert_only(self):
+        """Certificate-only selection maps to cert suffix."""
+        target = {"type_": "retention", "max_academic_year": "2024"}
+        checkpoint = {"type_": "first_within_cohort"}
+        student_criteria = {
+            "intended_program_type": "UNDERGRADUATE CERTIFICATE OR DIPLOMA PROGRAM",
+        }
+
+        result = pdp_get_model_name(
+            target=target,
+            checkpoint=checkpoint,
+            student_criteria=student_criteria,
+        )
+        assert result == "retention_into_year_2_cert"
+
+    def test_retention_with_associates_and_bachelors(self):
+        target = {"type_": "retention", "max_academic_year": "2024"}
+        checkpoint = {"type_": "first_within_cohort"}
+        student_criteria = {
+            "intended_program_type": ["ASSOCIATE'S DEGREE", "BACHELOR'S DEGREE"],
+        }
+
+        result = pdp_get_model_name(
+            target=target,
+            checkpoint=checkpoint,
+            student_criteria=student_criteria,
+        )
+        assert result == "retention_into_year_2_associates_and_bachelors"
+
+    def test_retention_with_associates_bachelors_and_cert(self):
+        target = {"type_": "retention", "max_academic_year": "2024"}
+        checkpoint = {"type_": "first_within_cohort"}
+        student_criteria = {
+            "intended_program_type": [
+                "ASSOCIATE'S DEGREE",
+                "BACHELOR'S DEGREE",
+                "UNDERGRADUATE CERTIFICATE OR DIPLOMA PROGRAM",
+            ],
+        }
+
+        result = pdp_get_model_name(
+            target=target,
+            checkpoint=checkpoint,
+            student_criteria=student_criteria,
+        )
+        assert result == "retention_into_year_2_associates_and_bachelors_and_cert"
+
+    def test_retention_with_empty_program_type(self):
+        """Empty credential criteria falls back to all_degrees."""
+        target = {"type_": "retention", "max_academic_year": "2024"}
+        checkpoint = {"type_": "first_within_cohort"}
+        student_criteria = {"intended_program_type": []}
+
+        result = pdp_get_model_name(
+            target=target,
+            checkpoint=checkpoint,
+            student_criteria=student_criteria,
+        )
+        assert result == "retention_into_year_2_all_degrees"
 
     def test_retention_prefers_pdp_credential_key_over_intended_program_type(self):
         """When both keys are present, PDP credential column takes precedence."""


### PR DESCRIPTION
Before, we only mapped to fixed suffix values if they matched the PDP criteria. Now, we always map to fixed suffixes if certain substrings are found, so edvise schools do not have super long model names!

## Description

## Asana Task
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1215982297254617

## Deployment Readiness\*

### Testing

Describe or check:

- [x] Created or updated unit, feature, and/or integration tests  
- [ ] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [x]  No special deployment steps required

### Rollback Plan

Describe or check:

- [x]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional