### PR TITLE
fix(integration): match all models in synthetic gold schema during integration test and weekly cleanup

### DIFF
--- a/src/edvise/scripts/pdp_synthetic_cleanup.py
+++ b/src/edvise/scripts/pdp_synthetic_cleanup.py
@@ -109,6 +109,12 @@ def rm_path(spark: SparkSession, path: str, recurse: bool, dry_run: bool) -> Non
         dbutils.fs.rm(path, recurse=recurse)
 
 
+def is_institution_gold_model(name: str, catalog: str, institution: str) -> bool:
+    """Return True if `name` is a UC model in the institution's gold schema."""
+    prefix = f"{catalog}.{institution}_gold."
+    return name.startswith(prefix)
+
+
 # --- UC-safe model deletion (replaces stage transition logic) ---
 def delete_uc_model_completely(client: MlflowClient, name: str, dry_run: bool) -> None:
     """
@@ -268,7 +274,7 @@ if __name__ == "__main__":
             client = MlflowClient()
             for rm in client.search_registered_models():
                 name = rm.name  # In UC this is "<catalog>.<schema>.<model_name>"
-                if name.startswith(f"{catalog}.{inst}_gold.{inst}"):
+                if is_institution_gold_model(name, catalog, inst):
                     log(f"DELETE model: {name}")
                     delete_uc_model_completely(client, name, dry_run)
         except Exception as e:

--- a/tests/scripts/test_pdp_synthetic_cleanup.py
+++ b/tests/scripts/test_pdp_synthetic_cleanup.py
@@ -1,0 +1,31 @@
+from edvise.scripts.pdp_synthetic_cleanup import is_institution_gold_model
+
+
+def test_is_institution_gold_model_matches_pdp_model_names():
+    catalog = "dev_sst_02"
+    institution = "synthetic_integration"
+    assert is_institution_gold_model(
+        "dev_sst_02.synthetic_integration_gold.retention_into_year_2_bachelors",
+        catalog,
+        institution,
+    )
+
+
+def test_is_institution_gold_model_matches_legacy_h2o_model_names():
+    catalog = "dev_sst_02"
+    institution = "synthetic_integration"
+    assert is_institution_gold_model(
+        "dev_sst_02.synthetic_integration_gold.synthetic_integration_retention_2_year_time_first_within_cohort_h2o_automl",
+        catalog,
+        institution,
+    )
+
+
+def test_is_institution_gold_model_rejects_other_schemas():
+    catalog = "dev_sst_02"
+    institution = "synthetic_integration"
+    assert not is_institution_gold_model(
+        "dev_sst_02.other_institution_gold.retention_into_year_2_bachelors",
+        catalog,
+        institution,
+    )


### PR DESCRIPTION
## Summary
- Broaden the synthetic cleanup model filter from `{catalog}.{inst}_gold.{inst}*` to `{catalog}.{inst}_gold.*` so PDP-registered models like `retention_into_year_2_bachelors` are included.
- Extract `is_institution_gold_model()` and add unit tests for PDP, legacy H2O, and cross-schema rejection cases.

## Context
The weekly cleanup job (`delete_models=true`) was silently skipping UC models because PDP model names no longer include the institution prefix in the model name segment (e.g. `dev_sst_02.synthetic_integration_gold.retention_into_year_2_bachelors`).

## Test plan
- [x] `uv run pytest tests/scripts/test_pdp_synthetic_cleanup.py`
- [x] Run `edvise_cleanup_synthetic` with `dry_run=true,delete_models=true` and confirm matching models are logged for deletion


Made with [Cursor](https://cursor.com)