### PR TITLE
fix(genai): ensure execution cleaning applies frozen dtypes before dedupe

### DIFF
--- a/src/edvise/data_audit/custom_cleaning.py
+++ b/src/edvise/data_audit/custom_cleaning.py
@@ -610,6 +610,7 @@ def clean_dataset(
     cleaning_cfg: "CleaningConfig | None" = None,
     *,
     canonical_learner_column: t.Literal["student_id", "learner_id"] = "student_id",
+    frozen_dataset_schema: dict | None = None,
 ) -> pd.DataFrame:
     """
     End-to-end cleaner with robust training-time dtype generation and consistent policies.
@@ -619,12 +620,13 @@ def clean_dataset(
           clean_dataset(..., generate_dtypes=True)
           -> build_schema_contract(...)
       - INFERENCE:
-          clean_dataset(..., generate_dtypes=False)  # if you still want cleaning hooks
+          clean_dataset(..., generate_dtypes=False, frozen_dataset_schema=...)
           then enforce_schema(...) using the frozen schema.
 
-    `generate_dtypes=False` is useful at inference to avoid re-generating dtypes
-    and introducing train–inference skew; instead, `enforce_schema` should dictate
-    the final dtypes.
+    At inference, pass ``frozen_dataset_schema`` (one entry from the onboard contract)
+    so dtypes are applied **before** ``dedupe_fn`` and primary-key dedupe, matching
+    the onboard order. ``generate_dtypes=False`` avoids heuristic re-inference;
+    ``frozen_dataset_schema`` supplies the frozen dtypes instead.
 
     ``canonical_learner_column``:
       - ``\"student_id\"`` (default): rename alias → ``student_id`` (custom audit behavior).
@@ -742,9 +744,17 @@ def clean_dataset(
             g.shape,
         )
 
-    # 6) generate dtypes at training-time
+    # 6) dtypes before dedupe — training: infer; inference: frozen contract
     if generate_dtypes:
         g = generate_training_dtypes(g, opts=inference_opts)
+    elif frozen_dataset_schema is not None:
+        g = _apply_frozen_dtypes_to_dataframe(
+            g, frozen_dataset_schema, dataset_name=dataset_name
+        )
+        LOGGER.info(
+            "%s - Applied frozen schema dtypes before dedupe (inference)",
+            dataset_name,
+        )
     if canonical_col in g.columns:
         g[canonical_col] = g[canonical_col].astype("string")
 
@@ -784,18 +794,12 @@ def clean_dataset(
         )
 
     if enforce_uniqueness:
-        # 10) deduplicate rows based on primary keys
-        before = len(g)
-        if spec.unique_keys:
-            g = g.drop_duplicates(subset=spec.unique_keys, keep="first").reset_index(
-                drop=True
-            )
-        LOGGER.info(
-            "%s - Deduplicated rows based on primary keys %s | %d removed | shape=%s",
-            dataset_name,
+        # 10) deduplicate rows based on primary keys (after dtypes at train + inference)
+        g = _dedupe_rows_on_unique_keys(
+            g,
             spec.unique_keys,
-            before - len(g),
-            g.shape,
+            dataset_name=dataset_name,
+            log_context="primary keys",
         )
 
         # 11) enforce uniqueness by primary keys
@@ -914,6 +918,79 @@ def _hash_list(values: list[str]) -> str:
     return "sha256:" + h.hexdigest()
 
 
+def _apply_frozen_dtypes_to_dataframe(
+    df: pd.DataFrame,
+    schema: dict,
+    *,
+    dataset_name: str = "",
+    add_missing_columns: bool = True,
+) -> pd.DataFrame:
+    """
+    Cast columns to dtypes from a frozen per-dataset schema (onboard contract).
+
+    Used at inference so dedupe hooks and primary-key dedupe run on the same typed
+    values as training/onboard (``generate_dtypes=True``), without re-running
+    heuristic dtype inference.
+    """
+    g = df.copy()
+    dtypes = schema.get("dtypes") or {}
+    if not dtypes:
+        return g
+
+    if add_missing_columns:
+        for col in dtypes:
+            if col not in g.columns:
+                g[col] = pd.NA
+
+    bmap = schema.get(
+        "boolean_map",
+        {
+            "true": True,
+            "false": False,
+            "yes": True,
+            "no": False,
+            "1": True,
+            "0": False,
+        },
+    )
+    label = dataset_name or "dataset"
+    for col, dt in dtypes.items():
+        if col not in g.columns:
+            continue
+        try:
+            g[col] = _cast_series_to_nullable_dtype(g[col], dt, bmap)
+        except Exception as e:
+            raise ValueError(
+                f"{label} - Failed to cast column {col} to {dt}: {e}"
+            ) from e
+    return g
+
+
+def _dedupe_rows_on_unique_keys(
+    df: pd.DataFrame,
+    keys: list[str] | None,
+    *,
+    dataset_name: str = "",
+    log_context: str = "primary keys",
+) -> pd.DataFrame:
+    """Drop duplicate rows on ``keys`` (keep first), matching onboard ``clean_dataset`` step 10."""
+    if not keys:
+        return df
+    before = len(df)
+    out = df.drop_duplicates(subset=keys, keep="first").reset_index(drop=True)
+    removed = before - len(out)
+    label = dataset_name or "dataset"
+    LOGGER.info(
+        "%s - Deduplicated rows based on %s %s | %d removed | shape=%s",
+        label,
+        log_context,
+        keys,
+        removed,
+        out.shape,
+    )
+    return out
+
+
 def freeze_schema(
     df: pd.DataFrame, spec: dict[str, t.Any], opts: SchemaFreezeOptions | None = None
 ) -> dict[str, t.Any]:
@@ -966,15 +1043,9 @@ def enforce_schema(df: pd.DataFrame, schema: dict) -> pd.DataFrame:
     g = g[expected]
 
     # 3) cast to frozen (nullable) dtypes
-    bmap = schema.get(
-        "boolean_map",
-        {"true": True, "false": False, "yes": True, "no": False, "1": True, "0": False},
+    g = _apply_frozen_dtypes_to_dataframe(
+        g, schema, add_missing_columns=False
     )
-    for c, dt in schema["dtypes"].items():
-        try:
-            g[c] = _cast_series_to_nullable_dtype(g[c], dt, bmap)
-        except Exception as e:
-            raise ValueError(f"Failed to cast column {c} to {dt}: {e}")
 
     # 4) enforce non-nulls
     nn = schema.get("non_null_columns", [])
@@ -983,9 +1054,14 @@ def enforce_schema(df: pd.DataFrame, schema: dict) -> pd.DataFrame:
         g = g.dropna(subset=nn, how="any")
         LOGGER.info("Enforce non-nulls %s: dropped %d rows", nn, before - len(g))
 
-    # 5) enforce key uniqueness
+    # 5) dedupe then enforce key uniqueness (same policy as onboard clean_dataset)
     keys = schema.get("unique_keys")
     if keys:
+        g = _dedupe_rows_on_unique_keys(
+            g,
+            keys,
+            log_context="unique keys at inference",
+        )
         dups = g.duplicated(subset=keys)
         if dups.any():
             raise ValueError(

--- a/src/edvise/data_audit/custom_cleaning.py
+++ b/src/edvise/data_audit/custom_cleaning.py
@@ -1043,9 +1043,7 @@ def enforce_schema(df: pd.DataFrame, schema: dict) -> pd.DataFrame:
     g = g[expected]
 
     # 3) cast to frozen (nullable) dtypes
-    g = _apply_frozen_dtypes_to_dataframe(
-        g, schema, add_missing_columns=False
-    )
+    g = _apply_frozen_dtypes_to_dataframe(g, schema, add_missing_columns=False)
 
     # 4) enforce non-nulls
     nn = schema.get("non_null_columns", [])

--- a/src/edvise/genai/mapping/identity_agent/execution/contract_builder.py
+++ b/src/edvise/genai/mapping/identity_agent/execution/contract_builder.py
@@ -267,6 +267,7 @@ def build_schema_contract_from_grain_contracts(
     hook_modules_root: str | Path | None = None,
     generate_dtypes: bool = True,
     build_frozen_contract: bool = True,
+    frozen_schema_contract: dict | None = None,
 ) -> tuple[dict[str, pd.DataFrame], dict]:
     """
     Build cleaned frames and a frozen schema contract (envelope uses ``student_id_alias`` from
@@ -275,9 +276,8 @@ def build_schema_contract_from_grain_contracts(
     Applies :func:`merge_grain_contracts_into_school_config` (primary keys + cleaning alias) then
     :func:`edvise.genai.mapping.shared.schema_contract.build_from_school_config.build_schema_contract_from_config`.
 
-    For inference without re-freezing, pass ``generate_dtypes=False`` and ``build_frozen_contract=False``
-    (same sequence as :func:`~edvise.data_audit.custom_cleaning.clean_dataset` then an existing
-    frozen contract + :func:`~edvise.data_audit.custom_cleaning.enforce_schema_contract`).
+    For inference without re-freezing, pass ``generate_dtypes=False``, ``build_frozen_contract=False``,
+    and ``frozen_schema_contract`` (the active onboard contract) so dtypes are applied before dedupe.
 
     Args:
         school_config: School mapping config (paths, cleaning, baseline primary_keys).
@@ -361,6 +361,7 @@ def build_schema_contract_from_grain_contracts(
         canonical_learner_column=canonical_learner_column,
         generate_dtypes=generate_dtypes,
         build_frozen_contract=build_frozen_contract,
+        frozen_schema_contract=frozen_schema_contract,
     )
 
 

--- a/src/edvise/genai/mapping/scripts/edvise_genai_ia.py
+++ b/src/edvise/genai/mapping/scripts/edvise_genai_ia.py
@@ -650,9 +650,8 @@ def run_onboard_gate_1(
 # Identity clean_dataset (inference) -> drift vs active frozen contract ->
 # enforce_schema_contract -> write cleaned Parquet -> exit
 #
-# Matches :func:`~edvise.data_audit.custom_cleaning.clean_dataset` inference guidance:
-# ``generate_dtypes=False`` then apply the **onboard-frozen** JSON via
-# :func:`~edvise.data_audit.custom_cleaning.enforce_schema_contract` (no re-freeze).
+# ``generate_dtypes=False`` + ``frozen_schema_contract`` (cast before dedupe), then
+# ``enforce_schema_contract`` for column alignment and final contract enforcement.
 # ---------------------------------------------------------------------------
 
 
@@ -858,7 +857,7 @@ def run_execute(
     )
 
     LOGGER.info(
-        "[execute] Identity cleaning (clean_dataset, generate_dtypes=False); "
+        "[execute] Identity cleaning (clean_dataset, generate_dtypes=False, frozen schema); "
         "then enforce active frozen contract per custom_cleaning inference pattern"
     )
     cleaned_pre_enforce, _ = build_schema_contract_from_grain_contracts(
@@ -870,6 +869,7 @@ def run_execute(
         hook_modules_root=hook_modules_root_resolved,
         generate_dtypes=False,
         build_frozen_contract=False,
+        frozen_schema_contract=schema_contract,
     )
 
     incoming_datasets = set(cleaned_pre_enforce.keys())

--- a/src/edvise/genai/mapping/shared/schema_contract/build_from_school_config.py
+++ b/src/edvise/genai/mapping/shared/schema_contract/build_from_school_config.py
@@ -225,6 +225,7 @@ def build_schema_contract_from_config(
     *,
     generate_dtypes: bool = True,
     build_frozen_contract: bool = True,
+    frozen_schema_contract: dict | None = None,
 ) -> tuple[dict[str, pd.DataFrame], dict]:
     """
     Build schema contract from inputs.toml SchoolMappingConfig.
@@ -254,6 +255,8 @@ def build_schema_contract_from_config(
             :func:`~edvise.data_audit.custom_cleaning.clean_dataset` docstring).
         build_frozen_contract: When ``False``, skip :func:`~edvise.data_audit.custom_cleaning.build_schema_contract`
             and return ``{}`` as the second value so callers keep an existing frozen JSON.
+        frozen_schema_contract: When ``generate_dtypes=False``, pass the active onboard contract
+            so each dataset is cast to frozen dtypes before dedupe (matches onboard order).
 
     Returns:
         Tuple of (cleaned_dataframes, schema_contract)
@@ -349,6 +352,15 @@ def build_schema_contract_from_config(
             "term_order_fn": dataset_term_order_fn,
         }
 
+        frozen_ds_schema: dict[str, Any] | None = None
+        if not generate_dtypes and frozen_schema_contract is not None:
+            datasets_schema = frozen_schema_contract.get("datasets") or {}
+            if logical_name not in datasets_schema:
+                raise KeyError(
+                    f"Dataset '{logical_name}' is not present in frozen_schema_contract"
+                )
+            frozen_ds_schema = datasets_schema[logical_name]
+
         df_clean = clean_dataset(
             df_raw,
             clean_spec,
@@ -358,6 +370,7 @@ def build_schema_contract_from_config(
             generate_dtypes=generate_dtypes,
             cleaning_cfg=merged_cleaning,
             canonical_learner_column=canonical_learner_column,
+            frozen_dataset_schema=frozen_ds_schema,
         )
 
         logger.info(

--- a/tests/data_audit/test_custom_cleaning.py
+++ b/tests/data_audit/test_custom_cleaning.py
@@ -320,16 +320,56 @@ def test_freeze_schema_and_enforce_schema_main_flow(caplog):
     )
 
 
-def test_enforce_schema_raises_on_unique_key_duplicates():
+def test_enforce_schema_dedupes_post_cast_key_collisions():
+    """Post-cast formatting duplicates collapse like onboard clean_dataset (keep first)."""
+    schema = {
+        "dtypes": {"course_number": "Int64", "learner_id": "string"},
+        "non_null_columns": [],
+        "unique_keys": ["learner_id", "course_number"],
+    }
+    df = pd.DataFrame(
+        {
+            "course_number": ["101", "101.0"],
+            "learner_id": ["s1", "s1"],
+            "grade": ["A", "B"],
+        }
+    )
+    out = enforce_schema(df, schema)
+    assert len(out) == 1
+    assert out.iloc[0]["course_number"] == 101
+    assert out.iloc[0]["learner_id"] == "s1"
+
+
+def test_clean_dataset_inference_applies_frozen_dtypes_before_key_dedupe():
+    """Execute path: frozen cast before dedupe matches onboard ordering."""
+    schema = {
+        "dtypes": {"id": "Int64"},
+        "non_null_columns": [],
+        "unique_keys": ["id"],
+    }
+    df = pd.DataFrame({"id": ["1", "1.0", "2"]})
+    spec = {"unique keys": ["id"]}
+    out = clean_dataset(
+        df,
+        spec,
+        dataset_name="courses",
+        generate_dtypes=False,
+        frozen_dataset_schema=schema,
+    )
+    assert len(out) == 2
+    assert list(out["id"]) == [1, 2]
+
+
+def test_enforce_schema_dedupes_identical_post_cast_keys():
     schema = {
         "dtypes": {"id": "Int64"},
         "non_null_columns": [],
         "unique_keys": ["id"],
     }
     df = pd.DataFrame({"id": [1, 1]})
-    with pytest.raises(ValueError) as exc:
-        enforce_schema(df, schema)
-    assert "Duplicate rows on unique keys" in str(exc.value)
+    out = enforce_schema(df, schema)
+    assert len(out) == 1
+    assert out.iloc[0]["id"] == 1
 
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
## Description
- Before we dedupe we then applied dtypes from onboarding and that created duplicated rows later. This then broke our pipeline validation.
- We want to apply the onboarding dtypes before dedupe. This will follow the same process from onboarding.
- Reproduced error on dev and confirmed fix.

## Asana Task
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216191705419806?focus=true

## Deployment Readiness\*

### Testing

Describe or check:

- [x] Created or updated unit, feature, and/or integration tests  
- [x] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [x]  No special deployment steps required

### Rollback Plan

Describe or check:

- [x]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional