### PR TITLE
fix(genai): adding in year_semantics into Term Config

### DIFF
--- a/src/edvise/genai/mapping/identity_agent/hitl/resolver.py
+++ b/src/edvise/genai/mapping/identity_agent/hitl/resolver.py
@@ -1076,6 +1076,10 @@ def _apply_term_resolution(
         term_cfg["season_col"] = None
         print(f"  → [{tbl}] term_col overridden: {resolution.term_col_override}")
 
+    if resolution.year_semantics is not None:
+        term_cfg["year_semantics"] = resolution.year_semantics
+        print(f"  → [{tbl}] year_semantics set: {resolution.year_semantics}")
+
     if resolution.hook_spec is not None:
         _apply_term_hook_spec_dict(
             term_cfg,

--- a/src/edvise/genai/mapping/identity_agent/hitl/resolver.py
+++ b/src/edvise/genai/mapping/identity_agent/hitl/resolver.py
@@ -96,6 +96,7 @@ from edvise.genai.mapping.identity_agent.term_normalization.schemas import (
     InstitutionTermContract,
     SeasonMapEntry,
     TermContract,
+    season_map_chronology_error,
 )
 from edvise.genai.mapping.identity_agent.term_normalization.validation import (
     assert_term_hook_groups_compatible,
@@ -1060,14 +1061,22 @@ def _apply_term_resolution(
         for raw_entry in resolution.season_map_replace:
             entry = SeasonMapEntry.model_validate(raw_entry)
             new_map.append(entry.model_dump(mode="json"))
+        chrono_err = season_map_chronology_error(new_map)
+        if chrono_err:
+            raise ValueError(f"[{tbl}] {chrono_err}")
         term_cfg["season_map"] = new_map
         print(f"  → [{tbl}] season_map replaced ({len(new_map)} entries)")
 
     if resolution.season_map_append:
         existing = term_cfg.setdefault("season_map", [])
+        merged_map = list(existing)
         for raw_entry in resolution.season_map_append:
             entry = SeasonMapEntry.model_validate(raw_entry)
-            existing.append(entry.model_dump(mode="json"))
+            merged_map.append(entry.model_dump(mode="json"))
+        chrono_err = season_map_chronology_error(merged_map)
+        if chrono_err:
+            raise ValueError(f"[{tbl}] {chrono_err}")
+        term_cfg["season_map"] = merged_map
         print(f"  → [{tbl}] season_map extended: {resolution.season_map_append}")
 
     if resolution.term_col_override:

--- a/src/edvise/genai/mapping/identity_agent/hitl/schemas.py
+++ b/src/edvise/genai/mapping/identity_agent/hitl/schemas.py
@@ -351,11 +351,14 @@ class TermResolution(BaseModel):
             "Column name for combined term encoding. Clears year_col and season_col when set."
         ),
     )
-    year_semantics: Literal[
-        "calendar_literal",
-        "academic_year_prefix",
-        "period_code",
-    ] | None = Field(
+    year_semantics: (
+        Literal[
+            "calendar_literal",
+            "academic_year_prefix",
+            "period_code",
+        ]
+        | None
+    ) = Field(
         default=None,
         description=(
             "Reviewer's decision for how the extracted year relates to the calendar year. "

--- a/src/edvise/genai/mapping/identity_agent/hitl/schemas.py
+++ b/src/edvise/genai/mapping/identity_agent/hitl/schemas.py
@@ -351,6 +351,21 @@ class TermResolution(BaseModel):
             "Column name for combined term encoding. Clears year_col and season_col when set."
         ),
     )
+    year_semantics: Literal[
+        "calendar_literal",
+        "academic_year_prefix",
+        "period_code",
+    ] | None = Field(
+        default=None,
+        description=(
+            "Reviewer's decision for how the extracted year relates to the calendar year. "
+            "'calendar_literal': extracted year is the calendar year (e.g. '2024SP' = Spring 2024). "
+            "'academic_year_prefix': extracted year is the academic-year start (e.g. '2017SR' = "
+            "Spring 2018); SPRING/SUMMER roll forward one calendar year. "
+            "'period_code': same roll-forward rule for numeric period codes (e.g. '2025-20' = "
+            "Spring 2026). Written to term_config.year_semantics when set."
+        ),
+    )
     hook_spec: HookSpec | None = Field(
         default=None,
         description=(

--- a/src/edvise/genai/mapping/identity_agent/hitl/schemas.py
+++ b/src/edvise/genai/mapping/identity_agent/hitl/schemas.py
@@ -355,18 +355,17 @@ class TermResolution(BaseModel):
         Literal[
             "calendar_literal",
             "academic_year_prefix",
-            "period_code",
         ]
         | None
     ) = Field(
         default=None,
         description=(
-            "Reviewer's decision for how the extracted year relates to the calendar year. "
+            "Reviewer's decision for how the extracted year relates to the calendar year "
+            "(year MEANING, independent of how the season is encoded). "
             "'calendar_literal': extracted year is the calendar year (e.g. '2024SP' = Spring 2024). "
-            "'academic_year_prefix': extracted year is the academic-year start (e.g. '2017SR' = "
-            "Spring 2018); SPRING/SUMMER roll forward one calendar year. "
-            "'period_code': same roll-forward rule for numeric period codes (e.g. '2025-20' = "
-            "Spring 2026). Written to term_config.year_semantics when set."
+            "'academic_year_prefix': extracted year is the academic-year start; SPRING/SUMMER roll "
+            "forward one calendar year (e.g. '2017SR' = Spring 2018, or a period code "
+            "'2025-20' = Spring 2026). Written to term_config.year_semantics when set."
         ),
     )
     hook_spec: HookSpec | None = Field(

--- a/src/edvise/genai/mapping/identity_agent/term_normalization/prompt.py
+++ b/src/edvise/genai/mapping/identity_agent/term_normalization/prompt.py
@@ -177,13 +177,19 @@ artifacts like ``.0`` (suffix season match breaks); **opaque** codes without a c
 
 ### Step 3 — Build `season_map`
 
-From unique values, identify all distinct season tokens. List them in **chronological order within a calendar year** (not academic year order).
+From unique values, identify all distinct season tokens. `season_map` is **ALWAYS** ordered by
+**calendar-year chronology**: `SPRING → SUMMER → FALL → WINTER`. This ordering never changes — it
+is independent of the raw token's spelling, its numeric value, and `year_semantics`.
 
 Rules:
 
 - Canonical label must be one of: `FALL`, `SPRING`, `SUMMER`, `WINTER`
 - Multiple raw tokens may share the same canonical label (e.g. `S1` and `S2` → `SUMMER`) but must appear as **separate entries** to preserve distinct chronological positions
 - Position in the list determines `season_rank` (1-indexed) used for `_term_order`
+- **Order by the canonical season's place in the calendar year, NOT by the raw token.** Sort by
+  `SPRING(1) < SUMMER(2) < FALL(3) < WINTER(4)`, ignoring the raw value. Do **not** order by numeric
+  code (`10`→FALL must come *after* `20`→SPRING even though 10 < 20), alphabetically, by academic-year
+  start (Fall does **not** go first), or by how the source file lists them.
 - For **Season_YYYY** formats, raw tokens are the spelled words as they appear: `"Fall"`, `"Spring"`
 - For opaque numeric or date formats where season cannot be observed, set `season_map: []`
 
@@ -365,13 +371,19 @@ artifacts like ``.0`` (suffix season match breaks); **opaque** codes without a c
 
 ### Step 3 — Build `season_map`
 
-From unique values, identify all distinct season tokens. List them in **chronological order within a calendar year** (not academic year order).
+From unique values, identify all distinct season tokens. `season_map` is **ALWAYS** ordered by
+**calendar-year chronology**: `SPRING → SUMMER → FALL → WINTER`. This ordering never changes — it
+is independent of the raw token's spelling, its numeric value, and `year_semantics`.
 
 Rules:
 
 - Canonical label must be one of: `FALL`, `SPRING`, `SUMMER`, `WINTER`
 - Multiple raw tokens may share the same canonical label (e.g. `S1` and `S2` → `SUMMER`) but must appear as **separate entries** to preserve distinct chronological positions
 - Position in the list determines `season_rank` (1-indexed) used for `_term_order`
+- **Order by the canonical season's place in the calendar year, NOT by the raw token.** Sort by
+  `SPRING(1) < SUMMER(2) < FALL(3) < WINTER(4)`, ignoring the raw value. Do **not** order by numeric
+  code (`10`→FALL must come *after* `20`→SPRING even though 10 < 20), alphabetically, by academic-year
+  start (Fall does **not** go first), or by how the source file lists them.
 - For **Season_YYYY** formats, raw tokens are the spelled words as they appear: `"Fall"`, `"Spring"`
 - For opaque numeric or date formats where season cannot be observed, set `season_map: []`
 

--- a/src/edvise/genai/mapping/identity_agent/term_normalization/prompt.py
+++ b/src/edvise/genai/mapping/identity_agent/term_normalization/prompt.py
@@ -254,6 +254,31 @@ Set `hitl_flag`: `true` when:
 - `term_candidates` was empty and term column was inferred from `raw_table_profile`
 - Unique values contain unrecognized tokens that could not be mapped to a canonical season
 - Confidence in the term column selection is low (multiple ambiguous candidates)
+- The term uses a **coded year prefix** whose calendar year is ambiguous (see YEAR SEMANTICS) —
+  emit a `year_semantics` HITL item for the reviewer to confirm.
+
+### YEAR SEMANTICS (emit a HITL item; do not set the value yourself)
+
+`term_config.year_semantics` controls whether the extracted year is the **calendar year**
+(`calendar_literal`, default) or an **academic-year start** (`academic_year_prefix` /
+`period_code`, where SPRING/SUMMER roll forward one calendar year). Leave `year_semantics`
+**null** in your output — you cannot disambiguate it from a single column, and guessing silently
+corrupts every downstream date. Instead flag it for HITL when the term uses a coded year prefix:
+
+- **YYYY + season suffix** — `2017SR`, `2018FA`, `2019SP` (the prefix could be the calendar year
+  *or* the academic-year start, e.g. `2017SR` = Spring 2017 vs Spring 2018)
+- **YYYY-NN period codes** — `2025-10`, `2025-20`
+- **Split year + season-code columns** — a numeric year column plus a short season/period code column
+
+Do **not** flag `year_semantics` for unambiguous shapes: spelled `Season YYYY` (`"Fall 2019"`),
+or datetime term columns — their year is already the calendar year.
+
+The HITL item is a simple `reentry: "terminal"` choice (not hook generation). Offer options whose
+`resolution` sets `year_semantics`, e.g.:
+
+- "Calendar year (e.g. 2017SR = Spring 2017)" → `{"year_semantics": "calendar_literal"}`
+- "Academic-year start (e.g. 2017SR = Spring 2018)" → `{"year_semantics": "academic_year_prefix"}`
+- "Period code (e.g. 2025-20 = Spring 2026)" → `{"year_semantics": "period_code"}`
 
 ### ACADEMIC YEAR CONVENTION (do not emit — for your reasoning only)
 
@@ -421,6 +446,8 @@ Set `hitl_flag`: `true` and emit at least one `HITLItem` when any of the followi
 - `term_candidates` was empty and term column was inferred from `raw_table_profile`
 - Unique values contain unrecognized tokens that could not be mapped to a canonical season
 - Confidence in the term column selection is low (multiple ambiguous candidates)
+- The term uses a **coded year prefix** whose calendar year is ambiguous (see YEAR SEMANTICS) —
+  emit a `reentry: "terminal"` `year_semantics` HITL item for the reviewer to confirm.
 
 When `hitl_flag` is `true`, emit one `HITLItem` per distinct ambiguity in `hitl_items`.
 When `hitl_flag` is `false`, emit `hitl_items: []`.
@@ -483,6 +510,32 @@ Good `hitl_question` examples:
   samples. Please confirm the extraction rule before hook generation proceeds."
 - "`term_enrolled_date` parses as dates (e.g. '1-Sep-19'). Confirm Jan–Apr→Spring, May–Jul→Summer,
   Aug–Dec→Fall before hook generation proceeds."
+- "`semester` uses `2017SR`-style codes. The 4-digit prefix could be the calendar year (Spring 2017)
+  or the academic-year start (Spring 2018). Confirm which `year_semantics` applies."
+
+### YEAR SEMANTICS (emit a HITL item; do not set the value yourself)
+
+`term_config.year_semantics` controls whether the extracted year is the **calendar year**
+(`calendar_literal`, default) or an **academic-year start** (`academic_year_prefix` /
+`period_code`, where SPRING/SUMMER roll forward one calendar year). Leave `year_semantics`
+**null** in your output — you cannot disambiguate it from a single column, and guessing silently
+corrupts every downstream date. Instead flag it for HITL when the term uses a coded year prefix:
+
+- **YYYY + season suffix** — `2017SR`, `2018FA`, `2019SP`
+- **YYYY-NN period codes** — `2025-10`, `2025-20`
+- **Split year + season-code columns** — a numeric year column plus a short season/period code column
+
+Do **not** flag `year_semantics` for spelled `Season YYYY` (`"Fall 2019"`) or datetime term columns —
+their year is already the calendar year.
+
+Emit a `reentry: "terminal"` HITLItem whose options set `year_semantics` (not hook generation):
+
+- "Calendar year (e.g. 2017SR = Spring 2017)" → `{"year_semantics": "calendar_literal"}`
+- "Academic-year start (e.g. 2017SR = Spring 2018)" → `{"year_semantics": "academic_year_prefix"}`
+- "Period code (e.g. 2025-20 = Spring 2026)" → `{"year_semantics": "period_code"}`
+
+This item is independent of hook generation: a `hook_required` term column can also carry a
+`year_semantics` item when its year prefix is ambiguous.
 
 ### ACADEMIC YEAR CONVENTION (do not emit — for your reasoning only)
 

--- a/src/edvise/genai/mapping/identity_agent/term_normalization/prompt.py
+++ b/src/edvise/genai/mapping/identity_agent/term_normalization/prompt.py
@@ -260,8 +260,10 @@ Set `hitl_flag`: `true` when:
 ### YEAR SEMANTICS (emit a HITL item; do not set the value yourself)
 
 `term_config.year_semantics` controls whether the extracted year is the **calendar year**
-(`calendar_literal`, default) or an **academic-year start** (`academic_year_prefix` /
-`period_code`, where SPRING/SUMMER roll forward one calendar year). Leave `year_semantics`
+(`calendar_literal`, default) or an **academic-year start** (`academic_year_prefix`, where
+SPRING/SUMMER roll forward one calendar year). This is about what the **year means**, NOT how the
+season is encoded — numeric period codes, letter suffixes, and spelled seasons are all handled by
+`season_map` / hooks and do not affect this choice. Leave `year_semantics`
 **null** in your output — you cannot disambiguate it from a single column, and guessing silently
 corrupts every downstream date. Instead flag it for HITL when the term uses a coded year prefix:
 
@@ -273,12 +275,13 @@ corrupts every downstream date. Instead flag it for HITL when the term uses a co
 Do **not** flag `year_semantics` for unambiguous shapes: spelled `Season YYYY` (`"Fall 2019"`),
 or datetime term columns — their year is already the calendar year.
 
-The HITL item is a simple `reentry: "terminal"` choice (not hook generation). Offer options whose
-`resolution` sets `year_semantics`, e.g.:
+The HITL item is a simple `reentry: "terminal"` choice (not hook generation). Offer exactly two
+options whose `resolution` sets `year_semantics`:
 
-- "Calendar year (e.g. 2017SR = Spring 2017)" → `{"year_semantics": "calendar_literal"}`
-- "Academic-year start (e.g. 2017SR = Spring 2018)" → `{"year_semantics": "academic_year_prefix"}`
-- "Period code (e.g. 2025-20 = Spring 2026)" → `{"year_semantics": "period_code"}`
+- "Calendar year (e.g. 2017SR = Spring 2017, or 2025-20 = Spring 2025)" →
+  `{"year_semantics": "calendar_literal"}`
+- "Academic-year start (e.g. 2017SR = Spring 2018, or 2025-20 = Spring 2026)" →
+  `{"year_semantics": "academic_year_prefix"}`
 
 ### ACADEMIC YEAR CONVENTION (do not emit — for your reasoning only)
 
@@ -516,8 +519,10 @@ Good `hitl_question` examples:
 ### YEAR SEMANTICS (emit a HITL item; do not set the value yourself)
 
 `term_config.year_semantics` controls whether the extracted year is the **calendar year**
-(`calendar_literal`, default) or an **academic-year start** (`academic_year_prefix` /
-`period_code`, where SPRING/SUMMER roll forward one calendar year). Leave `year_semantics`
+(`calendar_literal`, default) or an **academic-year start** (`academic_year_prefix`, where
+SPRING/SUMMER roll forward one calendar year). This is about what the **year means**, NOT how the
+season is encoded — numeric period codes, letter suffixes, and spelled seasons are all handled by
+`season_map` / hooks and do not affect this choice. Leave `year_semantics`
 **null** in your output — you cannot disambiguate it from a single column, and guessing silently
 corrupts every downstream date. Instead flag it for HITL when the term uses a coded year prefix:
 
@@ -528,11 +533,12 @@ corrupts every downstream date. Instead flag it for HITL when the term uses a co
 Do **not** flag `year_semantics` for spelled `Season YYYY` (`"Fall 2019"`) or datetime term columns —
 their year is already the calendar year.
 
-Emit a `reentry: "terminal"` HITLItem whose options set `year_semantics` (not hook generation):
+Emit a `reentry: "terminal"` HITLItem whose two options set `year_semantics` (not hook generation):
 
-- "Calendar year (e.g. 2017SR = Spring 2017)" → `{"year_semantics": "calendar_literal"}`
-- "Academic-year start (e.g. 2017SR = Spring 2018)" → `{"year_semantics": "academic_year_prefix"}`
-- "Period code (e.g. 2025-20 = Spring 2026)" → `{"year_semantics": "period_code"}`
+- "Calendar year (e.g. 2017SR = Spring 2017, or 2025-20 = Spring 2025)" →
+  `{"year_semantics": "calendar_literal"}`
+- "Academic-year start (e.g. 2017SR = Spring 2018, or 2025-20 = Spring 2026)" →
+  `{"year_semantics": "academic_year_prefix"}`
 
 This item is independent of hook generation: a `hook_required` term column can also carry a
 `year_semantics` item when its year prefix is ambiguous.

--- a/src/edvise/genai/mapping/identity_agent/term_normalization/prompt.py
+++ b/src/edvise/genai/mapping/identity_agent/term_normalization/prompt.py
@@ -283,6 +283,10 @@ options whose `resolution` sets `year_semantics`:
 - "Academic-year start (e.g. 2017SR = Spring 2018, or 2025-20 = Spring 2026)" →
   `{"year_semantics": "academic_year_prefix"}`
 
+`year_semantics` is independent of `season_map` ordering. Order `season_map` **calendar-chronologically**
+regardless of semantics — SPRING before SUMMER before FALL. Do **not** rank by the numeric period
+code or by academic-year start: `20`→SPRING must precede `10`→FALL in the list even though 10 < 20.
+
 ### ACADEMIC YEAR CONVENTION (do not emit — for your reasoning only)
 
 `_edvise_term_academic_year` is derived deterministically by `add_edvise_term_labels`:
@@ -539,6 +543,10 @@ Emit a `reentry: "terminal"` HITLItem whose two options set `year_semantics` (no
   `{"year_semantics": "calendar_literal"}`
 - "Academic-year start (e.g. 2017SR = Spring 2018, or 2025-20 = Spring 2026)" →
   `{"year_semantics": "academic_year_prefix"}`
+
+`year_semantics` is independent of `season_map` ordering. Order `season_map` **calendar-chronologically**
+regardless of semantics — SPRING before SUMMER before FALL. Do **not** rank by the numeric period
+code or by academic-year start: `20`→SPRING must precede `10`→FALL in the list even though 10 < 20.
 
 This item is independent of hook generation: a `hook_required` term column can also carry a
 `year_semantics` item when its year prefix is ambiguous.

--- a/src/edvise/genai/mapping/identity_agent/term_normalization/schemas.py
+++ b/src/edvise/genai/mapping/identity_agent/term_normalization/schemas.py
@@ -100,11 +100,14 @@ class TermOrderConfig(BaseModel):
         ),
     )
     term_extraction: Literal["standard", "hook_required"]
-    year_semantics: Literal[
-        "calendar_literal",
-        "academic_year_prefix",
-        "period_code",
-    ] | None = Field(
+    year_semantics: (
+        Literal[
+            "calendar_literal",
+            "academic_year_prefix",
+            "period_code",
+        ]
+        | None
+    ) = Field(
         default=None,
         description=(
             "How the extracted year relates to the calendar year of the term. "

--- a/src/edvise/genai/mapping/identity_agent/term_normalization/schemas.py
+++ b/src/edvise/genai/mapping/identity_agent/term_normalization/schemas.py
@@ -21,6 +21,47 @@ from edvise.genai.mapping.shared.hitl import PIPELINE_HITL_CONFIDENCE_THRESHOLD
 
 CANONICAL_SEASONS = {"FALL", "SPRING", "SUMMER", "WINTER"}
 
+# Calendar-year rank for season_map ordering validation (SPRING → SUMMER → FALL → WINTER).
+CALENDAR_CHRONOLOGY_RANK: dict[str, int] = {
+    "SPRING": 1,
+    "SUMMER": 2,
+    "FALL": 3,
+    "WINTER": 4,
+}
+
+
+def season_map_chronology_error(
+    season_map: list[SeasonMapEntry] | list[dict[str, str]],
+) -> str | None:
+    """
+    Return an error message when ``season_map`` canonicals are not calendar-chronological.
+
+    Duplicate canonicals are allowed (e.g. two SUMMER entries); only the canonical season's
+    calendar position must be non-decreasing left-to-right. Empty maps are valid (hooks/HITL
+    may populate later).
+    """
+    if not season_map:
+        return None
+
+    ranked: list[tuple[int, int, str]] = []
+    for i, entry in enumerate(season_map):
+        canonical = (
+            entry.canonical if isinstance(entry, SeasonMapEntry) else entry["canonical"]
+        ).upper()
+        rank = CALENDAR_CHRONOLOGY_RANK[canonical]
+        ranked.append((i + 1, rank, canonical))
+
+    for j in range(1, len(ranked)):
+        prev_pos, prev_rank, prev_canon = ranked[j - 1]
+        pos, rank, canon = ranked[j]
+        if rank < prev_rank:
+            return (
+                "season_map must be calendar-chronological "
+                "(SPRING → SUMMER → FALL → WINTER): "
+                f"{prev_canon} (position {prev_pos}) precedes {canon} (position {pos})"
+            )
+    return None
+
 
 class SeasonMapEntry(BaseModel):
     """One entry in the ordered season_map list."""
@@ -169,6 +210,13 @@ class TermOrderConfig(BaseModel):
                 )
         return self
 
+    @model_validator(mode="after")
+    def _season_map_calendar_chronological(self) -> TermOrderConfig:
+        err = season_map_chronology_error(self.season_map)
+        if err:
+            raise ValueError(err)
+        return self
+
 
 class TermContract(BaseModel):
     """
@@ -271,6 +319,7 @@ def get_term_contract_schema_context(
 
 
 __all__ = [
+    "CALENDAR_CHRONOLOGY_RANK",
     "CANONICAL_SEASONS",
     "HookFunctionSpec",
     "HookSpec",
@@ -279,4 +328,5 @@ __all__ = [
     "TermContract",
     "TermOrderConfig",
     "get_term_contract_schema_context",
+    "season_map_chronology_error",
 ]

--- a/src/edvise/genai/mapping/identity_agent/term_normalization/schemas.py
+++ b/src/edvise/genai/mapping/identity_agent/term_normalization/schemas.py
@@ -104,20 +104,20 @@ class TermOrderConfig(BaseModel):
         Literal[
             "calendar_literal",
             "academic_year_prefix",
-            "period_code",
         ]
         | None
     ) = Field(
         default=None,
         description=(
-            "How the extracted year relates to the calendar year of the term. "
+            "How the extracted year relates to the calendar year of the term. This is about "
+            "year MEANING, not season encoding: how the season is spelled (e.g. '2024SP', "
+            "'Fall 2019', numeric period codes like '2025-20') is handled entirely by "
+            "season_map / hooks and is irrelevant here. "
             "null / 'calendar_literal' (default): the extracted year IS the calendar year "
             "(e.g. '2024SP' = Spring 2024, 'Fall 2019' = Fall 2019). "
-            "'academic_year_prefix': the year is the academic-year start "
-            "(e.g. '2017SR' = Spring 2018); FALL/WINTER keep the year, SPRING/SUMMER roll "
-            "forward one calendar year. "
-            "'period_code': same calendar-year rule for numeric period codes "
-            "(e.g. '2025-10' = Fall 2025, '2025-20' = Spring 2026). "
+            "'academic_year_prefix': the extracted year is the academic-year start; FALL/WINTER "
+            "keep the year, SPRING/SUMMER roll forward one calendar year "
+            "(e.g. '2017SR' = Spring 2018, or a period code '2025-20' = Spring 2026). "
             "Applies to both combined term_col and split year_col/season_col configs."
         ),
     )

--- a/src/edvise/genai/mapping/identity_agent/term_normalization/schemas.py
+++ b/src/edvise/genai/mapping/identity_agent/term_normalization/schemas.py
@@ -100,6 +100,24 @@ class TermOrderConfig(BaseModel):
         ),
     )
     term_extraction: Literal["standard", "hook_required"]
+    year_semantics: Literal[
+        "calendar_literal",
+        "academic_year_prefix",
+        "period_code",
+    ] | None = Field(
+        default=None,
+        description=(
+            "How the extracted year relates to the calendar year of the term. "
+            "null / 'calendar_literal' (default): the extracted year IS the calendar year "
+            "(e.g. '2024SP' = Spring 2024, 'Fall 2019' = Fall 2019). "
+            "'academic_year_prefix': the year is the academic-year start "
+            "(e.g. '2017SR' = Spring 2018); FALL/WINTER keep the year, SPRING/SUMMER roll "
+            "forward one calendar year. "
+            "'period_code': same calendar-year rule for numeric period codes "
+            "(e.g. '2025-10' = Fall 2025, '2025-20' = Spring 2026). "
+            "Applies to both combined term_col and split year_col/season_col configs."
+        ),
+    )
     hook_spec: HookSpec | None = Field(
         default=None,
         description=(

--- a/src/edvise/genai/mapping/identity_agent/term_normalization/schemas.py
+++ b/src/edvise/genai/mapping/identity_agent/term_normalization/schemas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from typing import Literal
 
 from pydantic import (
@@ -31,7 +32,7 @@ CALENDAR_CHRONOLOGY_RANK: dict[str, int] = {
 
 
 def season_map_chronology_error(
-    season_map: list[SeasonMapEntry] | list[dict[str, str]],
+    season_map: Sequence[SeasonMapEntry | Mapping[str, str]],
 ) -> str | None:
     """
     Return an error message when ``season_map`` canonicals are not calendar-chronological.

--- a/src/edvise/genai/mapping/identity_agent/term_normalization/term_order.py
+++ b/src/edvise/genai/mapping/identity_agent/term_normalization/term_order.py
@@ -158,11 +158,38 @@ def _add_term_grain(df: pd.DataFrame, cols: EdviseTermColumnSet) -> pd.DataFrame
     return out
 
 
+def _calendar_year_from_semantics(
+    year: pd.Series,
+    season_norm: pd.Series,
+    raw_to_canonical: dict[str, str],
+    year_semantics: str | None,
+) -> pd.Series:
+    """
+    Adjust an extracted term year to a calendar year based on ``year_semantics``.
+
+    ``None`` / ``"calendar_literal"`` leaves the year unchanged (extracted year is already
+    the calendar year). For ``"academic_year_prefix"`` and ``"period_code"``, the extracted
+    year is the academic-year start: FALL/WINTER keep it, while SPRING/SUMMER roll forward one
+    calendar year. Rows with an unmapped season are left unchanged.
+
+    Downstream (``add_edvise_term_labels``) always treats ``_year`` as the calendar year, so
+    this conversion keeps academic-year labels and term ordering consistent across encodings.
+    """
+    if year_semantics in (None, "calendar_literal"):
+        return year
+    canonical = season_norm.astype("string").str.lower().map(raw_to_canonical)
+    rolls_forward = canonical.notna() & ~canonical.isin(_ACADEMIC_YEAR_START_SEASONS)
+    return year.where(~rolls_forward, other=year + 1)
+
+
 def _finalize_season_year_order(
     out: pd.DataFrame,
     season_norm: pd.Series,
     raw_to_rank: dict[str, int],
     cols: EdviseTermColumnSet,
+    *,
+    raw_to_canonical: dict[str, str] | None = None,
+    year_semantics: str | None = None,
 ) -> pd.DataFrame:
     out = out.copy()
     out[cols.season] = season_norm.astype("string")
@@ -179,6 +206,10 @@ def _finalize_season_year_order(
         mask = season_norm.isin(valid)
         out = out[mask]
         season_norm = season_norm[mask]
+
+    out[cols.year] = _calendar_year_from_semantics(
+        out[cols.year], season_norm, raw_to_canonical or {}, year_semantics
+    )
 
     season_rank = season_norm.map(raw_to_rank).astype("Int64")
     out[cols.term_order] = (out[cols.year] * 100 + season_rank).astype("Int64")
@@ -208,7 +239,10 @@ def add_edvise_term_order(
         - ``term_col``: single column encoding both year and season; or
         - ``year_col`` and ``season_col``: separate columns (mutually exclusive with ``term_col``).
 
-        Also ``season_map``, ``term_extraction`` (``standard`` | ``hook_required``).
+        Also ``season_map``, ``term_extraction`` (``standard`` | ``hook_required``), and optional
+        ``year_semantics`` (``calendar_literal`` default | ``academic_year_prefix`` | ``period_code``)
+        controlling whether the extracted year is treated as the calendar year or an academic-year
+        start (SPRING/SUMMER roll forward one calendar year).
     year_extractor : callable | None
         Required when term_config["term_extraction"] == "hook_required" (combined ``term_col`` only).
     season_extractor : callable | None
@@ -260,6 +294,10 @@ def add_edvise_term_order(
         )
 
     raw_to_rank, norm_keys = _season_map_lookups(season_map)
+    raw_to_canonical = {
+        item["raw"].lower(): item["canonical"].upper() for item in season_map
+    }
+    year_semantics = term_config.get("year_semantics")
     out = df.copy()
 
     exclude_tokens = [
@@ -295,7 +333,14 @@ def add_edvise_term_order(
             return _resolve_season_token(_norm_token(str(val).strip()), norm_keys)
 
         season_norm = s_season.map(_cell_to_season_norm)
-        ordered = _finalize_season_year_order(out, season_norm, raw_to_rank, cols)
+        ordered = _finalize_season_year_order(
+            out,
+            season_norm,
+            raw_to_rank,
+            cols,
+            raw_to_canonical=raw_to_canonical,
+            year_semantics=year_semantics,
+        )
         ordered = _add_term_grain(ordered, cols)
         return add_edvise_term_labels(ordered, term_config, columns=cols)
 
@@ -324,7 +369,14 @@ def add_edvise_term_order(
 
         season_norm = s.apply(_extract_season)
 
-    ordered = _finalize_season_year_order(out, season_norm, raw_to_rank, cols)
+    ordered = _finalize_season_year_order(
+        out,
+        season_norm,
+        raw_to_rank,
+        cols,
+        raw_to_canonical=raw_to_canonical,
+        year_semantics=year_semantics,
+    )
     ordered = _add_term_grain(ordered, cols)
     return add_edvise_term_labels(ordered, term_config, columns=cols)
 

--- a/src/edvise/genai/mapping/identity_agent/term_normalization/term_order.py
+++ b/src/edvise/genai/mapping/identity_agent/term_normalization/term_order.py
@@ -168,9 +168,10 @@ def _calendar_year_from_semantics(
     Adjust an extracted term year to a calendar year based on ``year_semantics``.
 
     ``None`` / ``"calendar_literal"`` leaves the year unchanged (extracted year is already
-    the calendar year). For ``"academic_year_prefix"`` and ``"period_code"``, the extracted
-    year is the academic-year start: FALL/WINTER keep it, while SPRING/SUMMER roll forward one
-    calendar year. Rows with an unmapped season are left unchanged.
+    the calendar year). For ``"academic_year_prefix"`` the extracted year is the academic-year
+    start: FALL/WINTER keep it, while SPRING/SUMMER roll forward one calendar year. This rule is
+    independent of how the season is encoded (letter suffix, numeric period code, spelled) — that
+    is resolved upstream by ``season_map`` / hooks. Rows with an unmapped season are left unchanged.
 
     Downstream (``add_edvise_term_labels``) always treats ``_year`` as the calendar year, so
     this conversion keeps academic-year labels and term ordering consistent across encodings.
@@ -240,9 +241,9 @@ def add_edvise_term_order(
         - ``year_col`` and ``season_col``: separate columns (mutually exclusive with ``term_col``).
 
         Also ``season_map``, ``term_extraction`` (``standard`` | ``hook_required``), and optional
-        ``year_semantics`` (``calendar_literal`` default | ``academic_year_prefix`` | ``period_code``)
-        controlling whether the extracted year is treated as the calendar year or an academic-year
-        start (SPRING/SUMMER roll forward one calendar year).
+        ``year_semantics`` (``calendar_literal`` default | ``academic_year_prefix``) controlling
+        whether the extracted year is treated as the calendar year or an academic-year start
+        (SPRING/SUMMER roll forward one calendar year).
     year_extractor : callable | None
         Required when term_config["term_extraction"] == "hook_required" (combined ``term_col`` only).
     season_extractor : callable | None

--- a/src/edvise/genai/mapping/identity_agent/term_normalization/validation.py
+++ b/src/edvise/genai/mapping/identity_agent/term_normalization/validation.py
@@ -29,6 +29,7 @@ from edvise.genai.mapping.identity_agent.term_normalization.schemas import (
     InstitutionTermContract,
     TermContract,
     TermOrderConfig,
+    season_map_chronology_error,
 )
 
 _SEASON_WORDS = frozenset(
@@ -290,6 +291,9 @@ def collect_term_semantic_validation_errors(
         mismatch = _hook_extractor_drafts_mismatch_term_shape(cfg)
         if mismatch:
             errors.append(f"[{table}] {mismatch}")
+        chrono_err = season_map_chronology_error(cfg.season_map)
+        if chrono_err:
+            errors.append(f"[{table}] {chrono_err}")
         columns = _profile_columns_for_dataset(run_by_dataset, table)
         if columns is not None:
             split_err = _split_columns_required_from_profile(table, cfg, columns)

--- a/tests/genai/mapping/identity_agent/test_execution.py
+++ b/tests/genai/mapping/identity_agent/test_execution.py
@@ -822,8 +822,8 @@ def test_apply_term_order_split_year_datetime_coerced_from_strings():
         year_col="year_code",
         season_col="term_code",
         season_map=[
-            {"raw": "10", "canonical": "FALL"},
             {"raw": "20", "canonical": "SPRING"},
+            {"raw": "10", "canonical": "FALL"},
         ],
         term_extraction="standard",
     )

--- a/tests/genai/mapping/identity_agent/test_execution.py
+++ b/tests/genai/mapping/identity_agent/test_execution.py
@@ -683,6 +683,104 @@ def test_apply_term_order_split_year_season_columns():
     assert "_term_order" in out.columns
 
 
+def test_year_semantics_default_is_calendar_literal():
+    """No year_semantics (or 'calendar_literal') keeps the extracted year as calendar year."""
+    df = pd.DataFrame({"term": ["2024SP", "2023FA"], "k": [1, 2]})
+    cfg = TermOrderConfig(
+        term_col="term",
+        season_map=[
+            {"raw": "SP", "canonical": "SPRING"},
+            {"raw": "FA", "canonical": "FALL"},
+        ],
+        term_extraction="standard",
+    )
+    out = apply_term_order_from_config(df, cfg)
+    assert list(out["_year"]) == [2024, 2023]
+    assert out.loc[out["term"] == "2024SP", "_edvise_term_academic_year"].iloc[0] == "2023-24"
+
+
+def test_year_semantics_academic_year_prefix_combined_col():
+    """YYYY+suffix codes: prefix is academic-year start; SPRING rolls forward one calendar year."""
+    df = pd.DataFrame({"semester": ["2016FR", "2017SR", "2018UR"], "k": [1, 2, 3]})
+    cfg = TermOrderConfig(
+        term_col="semester",
+        season_map=[
+            {"raw": "SR", "canonical": "SPRING"},
+            {"raw": "UR", "canonical": "SUMMER"},
+            {"raw": "FR", "canonical": "FALL"},
+        ],
+        term_extraction="standard",
+        year_semantics="academic_year_prefix",
+    )
+    out = apply_term_order_from_config(df, cfg).set_index("k")
+    # FALL keeps prefix year; SPRING/SUMMER roll forward one calendar year.
+    assert out.loc[1, "_year"] == 2016  # 2016FR -> Fall 2016
+    assert out.loc[2, "_year"] == 2018  # 2017SR -> Spring 2018
+    assert out.loc[3, "_year"] == 2019  # 2018UR -> Summer 2019
+    # term_order stays chronological: Fall 2016 < Spring 2018 < Summer 2019
+    assert out.loc[1, "_term_order"] < out.loc[2, "_term_order"] < out.loc[3, "_term_order"]
+
+
+def test_year_semantics_period_code_combined_col(tmp_path):
+    """YYYY-NN period codes (hook-extracted): 10=Fall (2025), 20=Spring (2026).
+
+    Combined ``YYYY-NN`` cannot use standard substring matching (the leading ``20`` of the year
+    collides with period code ``20``), so extraction is hook-based; ``year_semantics`` then applies
+    the calendar-year roll-forward on top of the extracted season token.
+    """
+    hook_dir = tmp_path / "identity_hooks" / "example"
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "term_hooks.py").write_text(
+        """
+def year_extractor_period(term):
+    return int(str(term).split("-")[0])
+
+def season_extractor_period(term):
+    return str(term).split("-")[1]
+"""
+    )
+    cfg = TermOrderConfig(
+        term_col="semester",
+        season_map=[
+            {"raw": "10", "canonical": "FALL"},
+            {"raw": "20", "canonical": "SPRING"},
+        ],
+        term_extraction="hook_required",
+        year_semantics="period_code",
+        hook_spec=HookSpec(
+            file="identity_hooks/example/term_hooks.py",
+            functions=[
+                HookFunctionSpec(name="year_extractor_period", description="year"),
+                HookFunctionSpec(name="season_extractor_period", description="season"),
+            ],
+        ),
+    )
+    df = pd.DataFrame({"semester": ["2025-10", "2025-20"], "k": [1, 2]})
+    out = apply_term_order_from_config(df, cfg, hook_modules_root=tmp_path).set_index("k")
+    assert out.loc[1, "_year"] == 2025  # 2025-10 -> Fall 2025
+    assert out.loc[2, "_year"] == 2026  # 2025-20 -> Spring 2026
+    assert out.loc[1, "_edvise_term_academic_year"] == "2025-26"
+    assert out.loc[2, "_edvise_term_academic_year"] == "2025-26"
+
+
+def test_year_semantics_period_code_split_columns():
+    """Split year + period-code columns share the same period_code semantics."""
+    df = pd.DataFrame({"yr": [2025, 2025], "term": ["10", "20"], "k": [1, 2]})
+    cfg = TermOrderConfig(
+        year_col="yr",
+        season_col="term",
+        season_map=[
+            {"raw": "10", "canonical": "FALL"},
+            {"raw": "20", "canonical": "SPRING"},
+        ],
+        term_extraction="standard",
+        year_semantics="period_code",
+    )
+    out = apply_term_order_from_config(df, cfg).set_index("k")
+    assert out.loc[1, "_year"] == 2025  # Fall 2025
+    assert out.loc[2, "_year"] == 2026  # Spring 2026
+
+
 def test_apply_term_order_split_year_datetime_coerced_from_strings():
     """year_col inferred as datetime64 (legacy schemas) still yields calendar _year."""
     df = pd.DataFrame(

--- a/tests/genai/mapping/identity_agent/test_execution.py
+++ b/tests/genai/mapping/identity_agent/test_execution.py
@@ -787,7 +787,11 @@ def test_year_semantics_period_code_split_columns():
     """Split year + period-code columns: period codes are just season encoding; the roll-forward
     comes from academic_year_prefix semantics."""
     df = pd.DataFrame(
-        {"yr": [2025, 2025, 2024, 2023], "term": ["10", "20", "10", "20"], "k": [1, 2, 3, 4]}
+        {
+            "yr": [2025, 2025, 2024, 2023],
+            "term": ["10", "20", "10", "20"],
+            "k": [1, 2, 3, 4],
+        }
     )
     cfg = TermOrderConfig(
         year_col="yr",

--- a/tests/genai/mapping/identity_agent/test_execution.py
+++ b/tests/genai/mapping/identity_agent/test_execution.py
@@ -750,9 +750,10 @@ def season_extractor_period(term):
     )
     cfg = TermOrderConfig(
         term_col="semester",
+        # season_map is calendar-chronological: SPRING (rank 1) precedes FALL (rank 2).
         season_map=[
-            {"raw": "10", "canonical": "FALL"},
             {"raw": "20", "canonical": "SPRING"},
+            {"raw": "10", "canonical": "FALL"},
         ],
         term_extraction="hook_required",
         year_semantics="academic_year_prefix",
@@ -764,33 +765,48 @@ def season_extractor_period(term):
             ],
         ),
     )
-    df = pd.DataFrame({"semester": ["2025-10", "2025-20"], "k": [1, 2]})
+    # 2023-20 (Spring 2024) and 2024-10 (Fall 2024) share calendar year 2024, so their
+    # relative order is decided purely by season_rank — Spring must sort before Fall.
+    df = pd.DataFrame(
+        {"semester": ["2025-10", "2025-20", "2024-10", "2023-20"], "k": [1, 2, 3, 4]}
+    )
     out = apply_term_order_from_config(df, cfg, hook_modules_root=tmp_path).set_index(
         "k"
     )
     assert out.loc[1, "_year"] == 2025  # 2025-10 -> Fall 2025
     assert out.loc[2, "_year"] == 2026  # 2025-20 -> Spring 2026
+    assert out.loc[3, "_year"] == 2024  # 2024-10 -> Fall 2024
+    assert out.loc[4, "_year"] == 2024  # 2023-20 -> Spring 2024
     assert out.loc[1, "_edvise_term_academic_year"] == "2025-26"
     assert out.loc[2, "_edvise_term_academic_year"] == "2025-26"
+    # Same calendar year 2024: Spring 2024 must precede Fall 2024 in term ordering.
+    assert out.loc[4, "_term_order"] < out.loc[3, "_term_order"]
 
 
 def test_year_semantics_period_code_split_columns():
     """Split year + period-code columns: period codes are just season encoding; the roll-forward
     comes from academic_year_prefix semantics."""
-    df = pd.DataFrame({"yr": [2025, 2025], "term": ["10", "20"], "k": [1, 2]})
+    df = pd.DataFrame(
+        {"yr": [2025, 2025, 2024, 2023], "term": ["10", "20", "10", "20"], "k": [1, 2, 3, 4]}
+    )
     cfg = TermOrderConfig(
         year_col="yr",
         season_col="term",
+        # Calendar-chronological order: SPRING (rank 1) precedes FALL (rank 2).
         season_map=[
-            {"raw": "10", "canonical": "FALL"},
             {"raw": "20", "canonical": "SPRING"},
+            {"raw": "10", "canonical": "FALL"},
         ],
         term_extraction="standard",
         year_semantics="academic_year_prefix",
     )
     out = apply_term_order_from_config(df, cfg).set_index("k")
-    assert out.loc[1, "_year"] == 2025  # Fall 2025
-    assert out.loc[2, "_year"] == 2026  # Spring 2026
+    assert out.loc[1, "_year"] == 2025  # 2025/10 -> Fall 2025
+    assert out.loc[2, "_year"] == 2026  # 2025/20 -> Spring 2026
+    assert out.loc[3, "_year"] == 2024  # 2024/10 -> Fall 2024
+    assert out.loc[4, "_year"] == 2024  # 2023/20 -> Spring 2024
+    # Same calendar year 2024: Spring 2024 must precede Fall 2024.
+    assert out.loc[4, "_term_order"] < out.loc[3, "_term_order"]
 
 
 def test_apply_term_order_split_year_datetime_coerced_from_strings():

--- a/tests/genai/mapping/identity_agent/test_execution.py
+++ b/tests/genai/mapping/identity_agent/test_execution.py
@@ -731,6 +731,8 @@ def test_year_semantics_academic_year_prefix_combined_col():
 def test_year_semantics_period_code_combined_col(tmp_path):
     """YYYY-NN period codes (hook-extracted): 10=Fall (2025), 20=Spring (2026).
 
+    Period-code season encoding is orthogonal to year semantics: the season tokens (10/20) are
+    resolved by season_map, and ``academic_year_prefix`` applies the calendar-year roll-forward.
     Combined ``YYYY-NN`` cannot use standard substring matching (the leading ``20`` of the year
     collides with period code ``20``), so extraction is hook-based; ``year_semantics`` then applies
     the calendar-year roll-forward on top of the extracted season token.
@@ -753,7 +755,7 @@ def season_extractor_period(term):
             {"raw": "20", "canonical": "SPRING"},
         ],
         term_extraction="hook_required",
-        year_semantics="period_code",
+        year_semantics="academic_year_prefix",
         hook_spec=HookSpec(
             file="identity_hooks/example/term_hooks.py",
             functions=[
@@ -773,7 +775,8 @@ def season_extractor_period(term):
 
 
 def test_year_semantics_period_code_split_columns():
-    """Split year + period-code columns share the same period_code semantics."""
+    """Split year + period-code columns: period codes are just season encoding; the roll-forward
+    comes from academic_year_prefix semantics."""
     df = pd.DataFrame({"yr": [2025, 2025], "term": ["10", "20"], "k": [1, 2]})
     cfg = TermOrderConfig(
         year_col="yr",
@@ -783,7 +786,7 @@ def test_year_semantics_period_code_split_columns():
             {"raw": "20", "canonical": "SPRING"},
         ],
         term_extraction="standard",
-        year_semantics="period_code",
+        year_semantics="academic_year_prefix",
     )
     out = apply_term_order_from_config(df, cfg).set_index("k")
     assert out.loc[1, "_year"] == 2025  # Fall 2025

--- a/tests/genai/mapping/identity_agent/test_execution.py
+++ b/tests/genai/mapping/identity_agent/test_execution.py
@@ -696,7 +696,10 @@ def test_year_semantics_default_is_calendar_literal():
     )
     out = apply_term_order_from_config(df, cfg)
     assert list(out["_year"]) == [2024, 2023]
-    assert out.loc[out["term"] == "2024SP", "_edvise_term_academic_year"].iloc[0] == "2023-24"
+    assert (
+        out.loc[out["term"] == "2024SP", "_edvise_term_academic_year"].iloc[0]
+        == "2023-24"
+    )
 
 
 def test_year_semantics_academic_year_prefix_combined_col():
@@ -718,7 +721,11 @@ def test_year_semantics_academic_year_prefix_combined_col():
     assert out.loc[2, "_year"] == 2018  # 2017SR -> Spring 2018
     assert out.loc[3, "_year"] == 2019  # 2018UR -> Summer 2019
     # term_order stays chronological: Fall 2016 < Spring 2018 < Summer 2019
-    assert out.loc[1, "_term_order"] < out.loc[2, "_term_order"] < out.loc[3, "_term_order"]
+    assert (
+        out.loc[1, "_term_order"]
+        < out.loc[2, "_term_order"]
+        < out.loc[3, "_term_order"]
+    )
 
 
 def test_year_semantics_period_code_combined_col(tmp_path):
@@ -756,7 +763,9 @@ def season_extractor_period(term):
         ),
     )
     df = pd.DataFrame({"semester": ["2025-10", "2025-20"], "k": [1, 2]})
-    out = apply_term_order_from_config(df, cfg, hook_modules_root=tmp_path).set_index("k")
+    out = apply_term_order_from_config(df, cfg, hook_modules_root=tmp_path).set_index(
+        "k"
+    )
     assert out.loc[1, "_year"] == 2025  # 2025-10 -> Fall 2025
     assert out.loc[2, "_year"] == 2026  # 2025-20 -> Spring 2026
     assert out.loc[1, "_edvise_term_academic_year"] == "2025-26"

--- a/tests/genai/mapping/identity_agent/test_hitl_resolver.py
+++ b/tests/genai/mapping/identity_agent/test_hitl_resolver.py
@@ -88,6 +88,49 @@ def test_term_col_override_clears_split_columns():
     assert tc["season_col"] is None
 
 
+def test_year_semantics_written_to_term_config():
+    cfg = {
+        "datasets": {
+            "t1": {
+                "term_config": {
+                    "term_col": "semester",
+                    "season_map": [
+                        {"raw": "SR", "canonical": "SPRING"},
+                        {"raw": "FR", "canonical": "FALL"},
+                    ],
+                    "term_extraction": "standard",
+                    "year_semantics": None,
+                }
+            }
+        }
+    }
+    res = TermResolution(year_semantics="academic_year_prefix")
+    _apply_term_resolution(cfg, _term_item(), res)
+    tc = cfg["datasets"]["t1"]["term_config"]
+    assert tc["year_semantics"] == "academic_year_prefix"
+    # Unrelated fields untouched.
+    assert tc["term_col"] == "semester"
+    assert tc["term_extraction"] == "standard"
+
+
+def test_year_semantics_absent_leaves_config_unchanged():
+    cfg = {
+        "datasets": {
+            "t1": {
+                "term_config": {
+                    "term_col": "term",
+                    "season_map": [{"raw": "FA", "canonical": "FALL"}],
+                    "term_extraction": "standard",
+                }
+            }
+        }
+    }
+    res = TermResolution(exclude_tokens=["Custom"])
+    _apply_term_resolution(cfg, _term_item(), res)
+    tc = cfg["datasets"]["t1"]["term_config"]
+    assert "year_semantics" not in tc
+
+
 def test_season_map_append_validates_entries():
     cfg = {
         "datasets": {

--- a/tests/genai/mapping/identity_agent/test_hitl_resolver.py
+++ b/tests/genai/mapping/identity_agent/test_hitl_resolver.py
@@ -149,6 +149,45 @@ def test_season_map_append_validates_entries():
         _apply_term_resolution(cfg, _term_item(), bad)
 
 
+def test_season_map_replace_rejects_non_chronological_order():
+    cfg = {
+        "datasets": {
+            "t1": {
+                "term_config": {
+                    "term_col": "semester",
+                    "season_map": [],
+                    "term_extraction": "hook_required",
+                }
+            }
+        }
+    }
+    bad = TermResolution(
+        season_map_replace=[
+            {"raw": "10", "canonical": "FALL"},
+            {"raw": "20", "canonical": "SPRING"},
+        ]
+    )
+    with pytest.raises(ValueError, match="calendar-chronological"):
+        _apply_term_resolution(cfg, _term_item(), bad)
+
+
+def test_season_map_append_rejects_non_chronological_merge():
+    cfg = {
+        "datasets": {
+            "t1": {
+                "term_config": {
+                    "term_col": "semester",
+                    "season_map": [{"raw": "10", "canonical": "FALL"}],
+                    "term_extraction": "hook_required",
+                }
+            }
+        }
+    }
+    bad = TermResolution(season_map_append=[{"raw": "20", "canonical": "SPRING"}])
+    with pytest.raises(ValueError, match="calendar-chronological"):
+        _apply_term_resolution(cfg, _term_item(), bad)
+
+
 def test_apply_grain_hook_spec_dict_sets_policy_required():
     grain_cfg = {
         "dedup_policy": {

--- a/tests/genai/mapping/identity_agent/test_term_validation.py
+++ b/tests/genai/mapping/identity_agent/test_term_validation.py
@@ -32,6 +32,7 @@ from edvise.genai.mapping.identity_agent.term_normalization.schemas import (
     InstitutionTermContract,
     TermContract,
     TermOrderConfig,
+    season_map_chronology_error,
 )
 from edvise.genai.mapping.identity_agent.term_normalization.validation import (
     assert_term_hook_groups_compatible,
@@ -99,8 +100,8 @@ def _shared_hitl_item() -> HITLItem:
     resolution = TermResolution(
         hook_spec=_hook_spec(),
         season_map_replace=[
-            {"raw": "10", "canonical": "FALL"},
             {"raw": "20", "canonical": "SPRING"},
+            {"raw": "10", "canonical": "FALL"},
         ],
     )
     return HITLItem(
@@ -338,3 +339,76 @@ def test_build_parse_rejects_st_thomas_bad_course_with_profile():
     )
     with pytest.raises(ValidationError):
         parse_fn(json.dumps(payload))
+
+
+def _minimal_term_config(*, season_map: list[dict[str, str]]) -> TermOrderConfig:
+    return TermOrderConfig(
+        term_col="semester",
+        season_map=season_map,
+        term_extraction="standard",
+    )
+
+
+def test_season_map_chronology_allows_duplicate_summer():
+    cfg = _minimal_term_config(
+        season_map=[
+            {"raw": "SR", "canonical": "SPRING"},
+            {"raw": "UL", "canonical": "SUMMER"},
+            {"raw": "UR", "canonical": "SUMMER"},
+            {"raw": "FR", "canonical": "FALL"},
+        ]
+    )
+    assert cfg.season_map[2].canonical == "SUMMER"
+
+
+def test_season_map_chronology_rejects_fall_before_spring():
+    with pytest.raises(ValidationError, match="calendar-chronological"):
+        _minimal_term_config(
+            season_map=[
+                {"raw": "10", "canonical": "FALL"},
+                {"raw": "20", "canonical": "SPRING"},
+            ]
+        )
+
+
+def test_season_map_chronology_error_detects_bad_order():
+    err = season_map_chronology_error(
+        [
+            {"raw": "10", "canonical": "FALL"},
+            {"raw": "20", "canonical": "SPRING"},
+        ]
+    )
+    assert err is not None
+    assert "FALL (position 1) precedes SPRING (position 2)" in err
+
+
+def test_collect_term_semantic_validation_errors_passes_valid_season_map():
+    inst = InstitutionTermContract(
+        institution_id=INST,
+        datasets={
+            "course": TermContract(
+                institution_id=INST,
+                table="course",
+                term_config=_minimal_term_config(
+                    season_map=[
+                        {"raw": "20", "canonical": "SPRING"},
+                        {"raw": "10", "canonical": "FALL"},
+                    ]
+                ),
+                confidence=0.75,
+                hitl_flag=False,
+                reasoning="ok",
+            )
+        },
+    )
+    assert collect_term_semantic_validation_errors(inst) == []
+
+
+def test_season_map_chronology_allows_empty_map():
+    cfg = TermOrderConfig(
+        term_col="semester",
+        season_map=[],
+        term_extraction="hook_required",
+        hook_spec=_hook_spec(),
+    )
+    assert cfg.season_map == []


### PR DESCRIPTION
## Description
- Some of our schools have implicit academic year prefix in their term code and we treat all schools as calendar year prefix.
- The result is for Spring and Summer students we were classifying "2024SR" as "2024 Spring", but really it was meant to be "2025 Spring".
- For now this is an HITL item where we basically ask the user to specify whether this is a calendar or academic prefix term code. I'm not asking the LLM to predict it (yet). 
- Tested on three schools and validated the final files that they were indeed bumped up by 1 for Spring and Summer terms.

## Asana Task
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216397343080594?focus=true

## Deployment Readiness\*

### Testing

Describe or check:

- [x] Created or updated unit, feature, and/or integration tests  
- [x] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [x]  No special deployment steps required

### Rollback Plan

Describe or check:

- [x]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*

## SOC 2 Change Management Checklist

- [ ] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional