### PR TITLE
fix: ensuring we have LLM retry for Haiku model during column roles task

### DIFF
--- a/src/edvise/genai/mapping/identity_agent/column_roles/__init__.py
+++ b/src/edvise/genai/mapping/identity_agent/column_roles/__init__.py
@@ -10,7 +10,12 @@ from .runner import (
     run_column_roles_for_dataset,
     run_column_roles_for_institution,
 )
-from .schemas import ColumnRole, ColumnRoleAssignment, ColumnRolesResult
+from .schemas import (
+    ColumnRole,
+    ColumnRoleAssignment,
+    ColumnRolesLLMResponse,
+    ColumnRolesResult,
+)
 from .file_kinds import FILE_KIND_EXPECTED_CONTENTS, FileKind, file_kind_prompt_section
 
 __all__ = [
@@ -19,6 +24,7 @@ __all__ = [
     "FILE_KIND_EXPECTED_CONTENTS",
     "ColumnRole",
     "ColumnRoleAssignment",
+    "ColumnRolesLLMResponse",
     "ColumnRolesResult",
     "FileKind",
     "build_column_roles_user_message",

--- a/src/edvise/genai/mapping/identity_agent/column_roles/prompt.py
+++ b/src/edvise/genai/mapping/identity_agent/column_roles/prompt.py
@@ -10,8 +10,8 @@ from edvise.genai.mapping.identity_agent.profiling.schemas import RawTableProfil
 from edvise.genai.mapping.shared.hitl import PIPELINE_HITL_CONFIDENCE_THRESHOLD
 from edvise.genai.mapping.shared.utilities import strip_json_fences
 
-from .file_kinds import FileKind, file_kind_prompt_section
-from .schemas import ColumnRoleAssignment, ColumnRolesResult
+from .file_kinds import file_kind_prompt_section
+from .schemas import ColumnRolesLLMResponse, ColumnRolesResult
 
 logger = logging.getLogger(__name__)
 
@@ -103,39 +103,16 @@ def parse_column_roles_response(
     text = raw.decode("utf-8") if isinstance(raw, bytes) else raw
     data = cast(dict[str, Any], json.loads(strip_json_fences(text)))
 
-    file_kind_raw = data.get("file_kind")
-    if not isinstance(file_kind_raw, str) or not file_kind_raw.strip():
-        raise ValueError("file_kind must be a non-empty string")
-    file_kind = FileKind(file_kind_raw.strip().lower())
+    # Structural + completeness validation lives in the Pydantic model so that an
+    # incomplete ``assignments`` list (e.g. the LLM omitting a column) raises a
+    # ``ValidationError`` and is retried with a correction hint by
+    # ``call_with_retry`` instead of hard-failing on the first response.
+    response = ColumnRolesLLMResponse.model_validate(
+        data, context={"expected_columns": list(expected_columns)}
+    )
 
-    file_kind_confidence = data.get("file_kind_confidence")
-    if not isinstance(file_kind_confidence, (int, float)):
-        raise ValueError("file_kind_confidence must be a number")
-    file_kind_rationale = str(data.get("file_kind_rationale") or "")
-
-    assignments_raw = data.get("assignments")
-    if not isinstance(assignments_raw, list):
-        raise ValueError("assignments must be a list")
-
-    assignments = [ColumnRoleAssignment.model_validate(x) for x in assignments_raw]
-    assigned_names = {a.column for a in assignments}
-    expected = list(expected_columns)
-    missing = [c for c in expected if c not in assigned_names]
-    if missing:
-        raise ValueError(f"Missing role assignments for columns: {missing}")
-
-    extra = assigned_names - set(expected)
-    if extra:
-        raise ValueError(f"Unexpected columns in assignments: {sorted(extra)}")
-
-    low_raw = data.get("low_confidence_columns", [])
-    if low_raw is None:
-        low_raw = []
-    if not isinstance(low_raw, list):
-        raise ValueError("low_confidence_columns must be a list or null")
-    low_confidence = [str(c) for c in low_raw]
-
-    for a in assignments:
+    low_confidence = list(response.low_confidence_columns)
+    for a in response.assignments:
         if (
             a.confidence < COLUMN_ROLES_CONFIDENCE_THRESHOLD
             and a.column not in low_confidence
@@ -145,9 +122,9 @@ def parse_column_roles_response(
     return ColumnRolesResult(
         institution_id=institution_id,
         dataset=dataset,
-        file_kind=file_kind,
-        file_kind_confidence=float(file_kind_confidence),
-        file_kind_rationale=file_kind_rationale,
-        assignments=assignments,
+        file_kind=response.file_kind,
+        file_kind_confidence=response.file_kind_confidence,
+        file_kind_rationale=response.file_kind_rationale,
+        assignments=response.assignments,
         low_confidence_columns=sorted(set(low_confidence)),
     )

--- a/src/edvise/genai/mapping/identity_agent/column_roles/schemas.py
+++ b/src/edvise/genai/mapping/identity_agent/column_roles/schemas.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import (
+    BaseModel,
+    Field,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
 
 from .file_kinds import FileKind
 
@@ -33,6 +39,58 @@ class ColumnRoleAssignment(BaseModel):
         default="",
         description="Brief reason for the label (audit only; not used downstream)",
     )
+
+
+class ColumnRolesLLMResponse(BaseModel):
+    """Structural + completeness validation of the raw ColumnRolesAgent JSON.
+
+    Completeness (every input column assigned exactly once) is enforced when the
+    caller supplies ``expected_columns`` via validation context. Because failures
+    surface as :class:`pydantic.ValidationError`, they are retried with a
+    correction hint by :func:`edvise.utils.llm_utils.call_with_retry` — an omitted
+    column no longer hard-fails the onboard run on the first response.
+    """
+
+    file_kind: FileKind
+    file_kind_confidence: float = Field(..., ge=0.0, le=1.0)
+    file_kind_rationale: str = ""
+    assignments: list[ColumnRoleAssignment]
+    low_confidence_columns: list[str] = Field(default_factory=list)
+
+    @field_validator("file_kind", mode="before")
+    @classmethod
+    def _normalize_file_kind(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.strip().lower()
+        return value
+
+    @field_validator("file_kind_rationale", mode="before")
+    @classmethod
+    def _coerce_rationale(cls, value: Any) -> str:
+        return str(value or "")
+
+    @field_validator("low_confidence_columns", mode="before")
+    @classmethod
+    def _coerce_low_confidence(cls, value: Any) -> Any:
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return [str(v) for v in value]
+        return value
+
+    @model_validator(mode="after")
+    def _check_expected_columns(self, info: ValidationInfo) -> "ColumnRolesLLMResponse":
+        expected = (info.context or {}).get("expected_columns")
+        if expected is None:
+            return self
+        assigned = {a.column for a in self.assignments}
+        missing = [c for c in expected if c not in assigned]
+        if missing:
+            raise ValueError(f"Missing role assignments for columns: {missing}")
+        extra = assigned - set(expected)
+        if extra:
+            raise ValueError(f"Unexpected columns in assignments: {sorted(extra)}")
+        return self
 
 
 class ColumnRolesResult(BaseModel):

--- a/tests/genai/mapping/identity_agent/test_column_roles.py
+++ b/tests/genai/mapping/identity_agent/test_column_roles.py
@@ -2,7 +2,9 @@ import json
 
 import pandas as pd
 import pytest
+from pydantic import ValidationError
 
+from edvise.utils.llm_utils import llm_complete_with_parse_retry
 from edvise.genai.mapping.identity_agent.column_roles.file_kinds import FileKind
 from edvise.genai.mapping.identity_agent.column_roles.fallback import (
     apply_column_role_fallbacks,
@@ -87,6 +89,74 @@ def test_parse_column_roles_response_requires_file_kind():
             dataset="student",
             expected_columns=["pidm"],
         )
+
+
+def _column_roles_payload(columns: list[str]) -> dict:
+    return {
+        "file_kind": "student",
+        "file_kind_confidence": 0.9,
+        "file_kind_rationale": "demographics table",
+        "assignments": [
+            {
+                "column": c,
+                "role": "learner_id" if c == "pidm" else "measure",
+                "confidence": 0.9,
+                "rationale": "test",
+            }
+            for c in columns
+        ],
+        "low_confidence_columns": [],
+    }
+
+
+def test_parse_column_roles_response_missing_column_raises_validation_error():
+    """A missing column must raise ``ValidationError`` so the shared retry helper retries."""
+    payload = _column_roles_payload(["pidm"])
+    with pytest.raises(ValidationError, match="dev_engl"):
+        parse_column_roles_response(
+            json.dumps(payload),
+            institution_id="test_u",
+            dataset="student",
+            expected_columns=["pidm", "dev_engl"],
+        )
+
+
+def test_parse_column_roles_response_extra_column_raises_validation_error():
+    payload = _column_roles_payload(["pidm", "surprise"])
+    with pytest.raises(ValidationError, match="surprise"):
+        parse_column_roles_response(
+            json.dumps(payload),
+            institution_id="test_u",
+            dataset="student",
+            expected_columns=["pidm"],
+        )
+
+
+def test_missing_column_is_retried_and_recovers():
+    """Omitting a column on the first response triggers a retry that then succeeds."""
+    calls: list[str] = []
+    incomplete = json.dumps(_column_roles_payload(["pidm"]))
+    complete = json.dumps(_column_roles_payload(["pidm", "dev_engl"]))
+
+    def llm_complete(system: str, user: str) -> str:
+        calls.append(user)
+        return incomplete if len(calls) == 1 else complete
+
+    def parse(raw: str):
+        return parse_column_roles_response(
+            raw,
+            institution_id="test_u",
+            dataset="student",
+            expected_columns=["pidm", "dev_engl"],
+        )
+
+    result = llm_complete_with_parse_retry(
+        llm_complete, "sys", "user", parse, max_retries=3
+    )
+    assert len(calls) == 2
+    assert {a.column for a in result.assignments} == {"pidm", "dev_engl"}
+    # The correction hint must be appended to the user message on the retry.
+    assert "dev_engl" in calls[1]
 
 
 def test_fallback_assigns_learner_id_from_name_pattern():


### PR DESCRIPTION
## Description

Currently if Haiku fails it's task, we don't prompt it again with the prompt + error that just happened. We do this for Sonnet on basically all LLM tasks in the GenAI pipeline, and it works really well. Basically want to copy that standard for Haiku so we have more robustness here. 

## Asana Task
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216403741978896?focus=true

## Deployment Readiness\*

### Testing

Describe or check:

- [x] Created or updated unit, feature, and/or integration tests  
- [x] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [x]  No special deployment steps required

### Rollback Plan

Describe or check:

- [x]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional