### PR TITLE
fix(genai): adding edge case & smarter fallback options for Haiku/column roles agent in prompt

### DIFF
--- a/src/edvise/genai/mapping/identity_agent/column_roles/fallback.py
+++ b/src/edvise/genai/mapping/identity_agent/column_roles/fallback.py
@@ -17,6 +17,7 @@ from .schemas import ColumnRole, ColumnRoleAssignment, ColumnRolesResult
 logger = logging.getLogger(__name__)
 
 _OMITTED_COLUMN_CONFIDENCE = 0.5
+_HIGH_LLM_OTHER_FRACTION = 0.25
 
 
 def _guess_role_for_omitted_column(column: str) -> tuple[ColumnRole, str]:
@@ -31,6 +32,30 @@ def _guess_role_for_omitted_column(column: str) -> tuple[ColumnRole, str]:
     if DEVELOPMENTAL_MEASURE_COLUMN_PATTERNS.search(name):
         return ColumnRole.MEASURE, "developmental/placement measure pattern"
     return ColumnRole.OTHER, "no name-pattern match for omitted column"
+
+
+def _warn_if_high_llm_other_rate(
+    assignments: dict[str, ColumnRoleAssignment],
+    columns: list[str],
+    warnings: list[str],
+) -> None:
+    """Surface when the LLM labeled many columns ``other`` (lazy classification)."""
+    if not columns:
+        return
+    llm_other = sorted(
+        a.column
+        for a in assignments.values()
+        if a.role == ColumnRole.OTHER and not a.rationale.startswith("fallback:")
+    )
+    frac = len(llm_other) / len(columns)
+    if frac <= _HIGH_LLM_OTHER_FRACTION:
+        return
+    msg = (
+        f"column_roles: {frac:.0%} of columns ({len(llm_other)}/{len(columns)}) "
+        f"labeled other by LLM: {llm_other}"
+    )
+    warnings.append(msg)
+    logger.warning(msg)
 
 
 def _assignment_map(result: ColumnRolesResult) -> dict[str, ColumnRoleAssignment]:
@@ -136,6 +161,8 @@ def apply_column_role_fallbacks(
             role.value,
             reason,
         )
+
+    _warn_if_high_llm_other_rate(assignments, columns, warnings)
 
     ordered = [assignments[c] for c in columns]
     return ColumnRolesResult(

--- a/src/edvise/genai/mapping/identity_agent/column_roles/fallback.py
+++ b/src/edvise/genai/mapping/identity_agent/column_roles/fallback.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from edvise.genai.mapping.identity_agent.profiling.constants import (
+    DEVELOPMENTAL_MEASURE_COLUMN_PATTERNS,
     INDEX_COLUMN_PATTERNS,
     STUDENT_ANCHOR_NAME_PATTERN,
     TERM_COLUMN_PATTERNS,
@@ -14,6 +15,22 @@ from .prompt import COLUMN_ROLES_CONFIDENCE_THRESHOLD
 from .schemas import ColumnRole, ColumnRoleAssignment, ColumnRolesResult
 
 logger = logging.getLogger(__name__)
+
+_OMITTED_COLUMN_CONFIDENCE = 0.5
+
+
+def _guess_role_for_omitted_column(column: str) -> tuple[ColumnRole, str]:
+    """Best-effort semantic role when the LLM omitted a column entirely."""
+    name = str(column)
+    if INDEX_COLUMN_PATTERNS.match(name):
+        return ColumnRole.INDEX, "index column pattern"
+    if STUDENT_ANCHOR_NAME_PATTERN.search(name):
+        return ColumnRole.LEARNER_ID, "student-anchor name pattern"
+    if TERM_COLUMN_PATTERNS.search(name):
+        return ColumnRole.TERM, "term name pattern"
+    if DEVELOPMENTAL_MEASURE_COLUMN_PATTERNS.search(name):
+        return ColumnRole.MEASURE, "developmental/placement measure pattern"
+    return ColumnRole.OTHER, "no name-pattern match for omitted column"
 
 
 def _assignment_map(result: ColumnRolesResult) -> dict[str, ColumnRoleAssignment]:
@@ -97,7 +114,30 @@ def apply_column_role_fallbacks(
                 col, ColumnRole.INDEX, reason="index column pattern", confidence=0.95
             )
 
-    ordered = [assignments[c] for c in columns if c in assignments]
+    for col in columns:
+        if col in assignments:
+            continue
+        role, reason = _guess_role_for_omitted_column(col)
+        assignments[col] = ColumnRoleAssignment(
+            column=col,
+            role=role,
+            confidence=_OMITTED_COLUMN_CONFIDENCE,
+            rationale=f"fallback: omitted from LLM response ({reason})",
+        )
+        fallback_applied.append(col)
+        low_confidence.add(col)
+        warnings.append(
+            f"column_roles_fallback: {col} -> {role.value} "
+            f"(omitted from LLM response; {reason})"
+        )
+        logger.info(
+            "ColumnRoles fallback: %s -> %s (omitted from LLM response; %s)",
+            col,
+            role.value,
+            reason,
+        )
+
+    ordered = [assignments[c] for c in columns]
     return ColumnRolesResult(
         institution_id=result.institution_id,
         dataset=result.dataset,

--- a/src/edvise/genai/mapping/identity_agent/column_roles/prompt.py
+++ b/src/edvise/genai/mapping/identity_agent/column_roles/prompt.py
@@ -37,15 +37,18 @@ Return a single JSON object (no markdown fences) with:
 - `program` — degree program, program_at_graduation, intended_program, college
 - `major` — major, concentration, field of study
 - `cohort` — cohort year, entry term, admit term, class year
-- `measure` — numeric or coded outcomes: GPA, credits, grades, counts, rates, amounts
+- `measure` — numeric or coded outcomes: GPA, credits, grades, counts, rates, amounts;
+  developmental/remedial placement flags (`dev_engl`, `dev_math`, `dev_read`, gateway flags)
 - `index` — synthetic row index (Unnamed: 0, row_number)
 - `metadata` — descriptive text not part of identifiers (names, titles, descriptions)
-- `other` — none of the above
+- `other` — none of the above (use sparingly; most columns map to a specific role)
 
 ## Rules
 1. Choose `file_kind` from column names, dtypes, and sample values — **not** from the logical
    dataset label in the user message (institutions misname files).
-2. Assign exactly one role per column from the input list.
+2. Include every input column in `assignments` — the array length must equal
+   `expected_assignment_count`. Never omit a column; make your best semantic guess and use
+   `confidence` (and `low_confidence_columns`) when uncertain.
 3. Use column names **and** sample values; institutions use different naming (pidm vs student_id).
 4. Float columns with grade/credit/GPA names are usually `measure`, not `learner_id`.
 5. High-cardinality opaque IDs matching person patterns → `learner_id` even if not named student_id.
@@ -81,11 +84,13 @@ def build_column_roles_user_message(
     dataset: str,
     raw_table_profile: RawTableProfile,
 ) -> str:
+    columns = _column_summaries_for_prompt(raw_table_profile)
     payload = {
         "institution_id": institution_id,
         "dataset": dataset,
         "row_count": raw_table_profile.row_count,
-        "columns": _column_summaries_for_prompt(raw_table_profile),
+        "expected_assignment_count": len(columns),
+        "columns": columns,
     }
     return (
         "Classify the file kind, then classify each column by semantic role.\n\n"
@@ -99,6 +104,7 @@ def parse_column_roles_response(
     institution_id: str,
     dataset: str,
     expected_columns: list[str],
+    validate_completeness: bool = True,
 ) -> ColumnRolesResult:
     text = raw.decode("utf-8") if isinstance(raw, bytes) else raw
     data = cast(dict[str, Any], json.loads(strip_json_fences(text)))
@@ -107,9 +113,10 @@ def parse_column_roles_response(
     # incomplete ``assignments`` list (e.g. the LLM omitting a column) raises a
     # ``ValidationError`` and is retried with a correction hint by
     # ``call_with_retry`` instead of hard-failing on the first response.
-    response = ColumnRolesLLMResponse.model_validate(
-        data, context={"expected_columns": list(expected_columns)}
-    )
+    context: dict[str, list[str]] | None = None
+    if validate_completeness:
+        context = {"expected_columns": list(expected_columns)}
+    response = ColumnRolesLLMResponse.model_validate(data, context=context)
 
     low_confidence = list(response.low_confidence_columns)
     for a in response.assignments:

--- a/src/edvise/genai/mapping/identity_agent/column_roles/runner.py
+++ b/src/edvise/genai/mapping/identity_agent/column_roles/runner.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from edvise.configs.genai import SchoolMappingConfig
 from edvise.data_audit.custom_cleaning import CleaningConfig
-from edvise.utils.llm_utils import llm_complete_with_parse_retry
+from edvise.utils.llm_utils import LLMRetryExhausted, llm_complete_with_parse_retry
 
 from edvise.genai.mapping.identity_agent.dataset_io import load_school_dataset_dataframe
 from edvise.genai.mapping.identity_agent.profiling.constants import (
@@ -57,22 +57,39 @@ def run_column_roles_for_dataset(
     user = build_column_roles_user_message(institution_id, dataset, raw_table_profile)
     expected_columns = [c.name for c in raw_table_profile.columns]
 
-    def _parse(raw: str) -> ColumnRolesResult:
+    def _parse(
+        raw: str,
+        *,
+        validate_completeness: bool = True,
+    ) -> ColumnRolesResult:
         parsed = parse_column_roles_response(
             raw,
             institution_id=institution_id,
             dataset=dataset,
             expected_columns=expected_columns,
+            validate_completeness=validate_completeness,
         )
         return apply_column_role_fallbacks(parsed, columns=expected_columns)
 
-    result = llm_complete_with_parse_retry(
-        llm_complete,
-        COLUMN_ROLES_SYSTEM_PROMPT,
-        user,
-        _parse,
-        logger=logger,
-    )
+    def _parse_strict(raw: str) -> ColumnRolesResult:
+        return _parse(raw, validate_completeness=True)
+
+    try:
+        result = llm_complete_with_parse_retry(
+            llm_complete,
+            COLUMN_ROLES_SYSTEM_PROMPT,
+            user,
+            _parse_strict,
+            logger=logger,
+        )
+    except LLMRetryExhausted as exc:
+        logger.warning(
+            "[column_roles] dataset=%s LLM retries exhausted (%s); "
+            "applying best-guess fallback for omitted columns",
+            dataset,
+            exc.last_error,
+        )
+        result = _parse(exc.last_raw_response, validate_completeness=False)
     logger.info(
         "[column_roles] dataset=%s file_kind=%s learner_id=%s low_confidence=%s warnings=%d",
         dataset,

--- a/src/edvise/genai/mapping/identity_agent/profiling/constants.py
+++ b/src/edvise/genai/mapping/identity_agent/profiling/constants.py
@@ -46,3 +46,10 @@ STUDENT_ANCHOR_NAME_PATTERN = re.compile(
     r"member[_\s]?id|participant[_\s]?id)",
     re.IGNORECASE,
 )
+
+DEVELOPMENTAL_MEASURE_COLUMN_PATTERNS = re.compile(
+    r"(?:^dev[_\s]?(?:engl|english|math|read)|"
+    r"attempted[_\s]?dev|completed[_\s]?dev|"
+    r"gateway|placement[_\s]?flag|remedial)",
+    re.IGNORECASE,
+)

--- a/tests/genai/mapping/identity_agent/test_column_roles.py
+++ b/tests/genai/mapping/identity_agent/test_column_roles.py
@@ -263,6 +263,31 @@ def test_missing_column_fallback_after_retry_exhausted():
     assert "dev_engl" in result.fallback_applied
 
 
+def test_fallback_warns_when_llm_labels_many_columns_other():
+    assignments = [
+        ColumnRoleAssignment(
+            column="pidm",
+            role=ColumnRole.LEARNER_ID,
+            confidence=0.95,
+            rationale="person id",
+        ),
+    ]
+    for i in range(3):
+        assignments.append(
+            ColumnRoleAssignment(
+                column=f"col_{i}",
+                role=ColumnRole.OTHER,
+                confidence=0.85,
+                rationale="unsure",
+            )
+        )
+    result = _roles(assignments=assignments)
+    patched = apply_column_role_fallbacks(
+        result, columns=["pidm", "col_0", "col_1", "col_2"]
+    )
+    assert any("labeled other by LLM" in w for w in patched.profiler_warnings)
+
+
 def test_fallback_assigns_learner_id_from_name_pattern():
     result = _roles(
         assignments=[

--- a/tests/genai/mapping/identity_agent/test_column_roles.py
+++ b/tests/genai/mapping/identity_agent/test_column_roles.py
@@ -10,7 +10,11 @@ from edvise.genai.mapping.identity_agent.column_roles.fallback import (
     apply_column_role_fallbacks,
 )
 from edvise.genai.mapping.identity_agent.column_roles.prompt import (
+    build_column_roles_user_message,
     parse_column_roles_response,
+)
+from edvise.genai.mapping.identity_agent.column_roles.runner import (
+    run_column_roles_for_dataset,
 )
 from edvise.genai.mapping.identity_agent.column_roles.schemas import (
     ColumnRole,
@@ -19,6 +23,10 @@ from edvise.genai.mapping.identity_agent.column_roles.schemas import (
 )
 from edvise.genai.mapping.identity_agent.profiling.candidate_keys import (
     profile_candidate_keys,
+)
+from edvise.genai.mapping.identity_agent.profiling.schemas import (
+    RawColumnProfile,
+    RawTableProfile,
 )
 from edvise.genai.mapping.identity_agent.profiling.semantic_keys import (
     build_semantic_key_column_sets,
@@ -82,7 +90,7 @@ def test_parse_column_roles_response_requires_file_kind():
         ],
         "low_confidence_columns": [],
     }
-    with pytest.raises(ValueError, match="file_kind"):
+    with pytest.raises(ValidationError, match="file_kind"):
         parse_column_roles_response(
             json.dumps(payload),
             institution_id="test_u",
@@ -157,6 +165,102 @@ def test_missing_column_is_retried_and_recovers():
     assert {a.column for a in result.assignments} == {"pidm", "dev_engl"}
     # The correction hint must be appended to the user message on the retry.
     assert "dev_engl" in calls[1]
+
+
+def test_build_column_roles_user_message_includes_expected_assignment_count():
+    profile = RawTableProfile(
+        institution_id="test_u",
+        dataset="student",
+        row_count=100,
+        column_count=2,
+        columns=[
+            RawColumnProfile(
+                name="pidm",
+                dtype="int64",
+                null_rate=0.0,
+                null_rate_including_tokens=0.0,
+                unique_count=100,
+                sample_values=["1", "2"],
+                is_term_candidate=False,
+            ),
+            RawColumnProfile(
+                name="dev_engl",
+                dtype="object",
+                null_rate=0.1,
+                null_rate_including_tokens=0.1,
+                unique_count=3,
+                sample_values=["Y", "N"],
+                is_term_candidate=False,
+            ),
+        ],
+    )
+    message = build_column_roles_user_message("test_u", "student", profile)
+    payload = json.loads(message.split("```json\n", 1)[1].rsplit("\n```", 1)[0])
+    assert payload["expected_assignment_count"] == 2
+    assert len(payload["columns"]) == 2
+
+
+def test_parse_column_roles_response_allows_missing_when_completeness_disabled():
+    payload = _column_roles_payload(["pidm"])
+    result = parse_column_roles_response(
+        json.dumps(payload),
+        institution_id="test_u",
+        dataset="student",
+        expected_columns=["pidm", "dev_engl"],
+        validate_completeness=False,
+    )
+    assert {a.column for a in result.assignments} == {"pidm"}
+
+
+def test_fallback_assigns_measure_for_omitted_dev_engl():
+    result = _roles(
+        assignments=[
+            ColumnRoleAssignment(
+                column="pidm",
+                role=ColumnRole.LEARNER_ID,
+                confidence=0.95,
+                rationale="person id",
+            ),
+        ],
+    )
+    patched = apply_column_role_fallbacks(result, columns=["pidm", "dev_engl"])
+    assert patched.role_for("dev_engl") == ColumnRole.MEASURE
+    assert "dev_engl" in patched.fallback_applied
+    assert "dev_engl" in patched.low_confidence_columns
+
+
+def test_fallback_assigns_other_for_omitted_unknown_column():
+    result = _roles(
+        assignments=[
+            ColumnRoleAssignment(
+                column="pidm",
+                role=ColumnRole.LEARNER_ID,
+                confidence=0.95,
+                rationale="person id",
+            ),
+        ],
+    )
+    patched = apply_column_role_fallbacks(result, columns=["pidm", "mystery_flag"])
+    assert patched.role_for("mystery_flag") == ColumnRole.OTHER
+    assert "mystery_flag" in patched.fallback_applied
+
+
+def test_missing_column_fallback_after_retry_exhausted():
+    incomplete = json.dumps(_column_roles_payload(["pidm"]))
+    df = pd.DataFrame({"pidm": [1, 2], "dev_engl": ["Y", "N"]})
+
+    def llm_complete(system: str, user: str) -> str:
+        return incomplete
+
+    result = run_column_roles_for_dataset(
+        institution_id="test_u",
+        dataset="student",
+        df=df,
+        llm_complete=llm_complete,
+    )
+    assert result.role_for("pidm") == ColumnRole.LEARNER_ID
+    assert result.role_for("dev_engl") == ColumnRole.MEASURE
+    assert "dev_engl" in result.fallback_applied
 
 
 def test_fallback_assigns_learner_id_from_name_pattern():


### PR DESCRIPTION
## Description
The column "dev_engl" is throwing off column roles agent and it perpetually chooses to not classify the column role for it. If Haiku still leaves something out after max retries, we fill in with "other".

## Asana Task
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216398611104964?focus=true

## Deployment Readiness\*

### Testing

Describe or check:

- [x] Created or updated unit, feature, and/or integration tests  
- [x] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [x]  No special deployment steps required

### Rollback Plan

Describe or check:

- [x]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional