### PR TITLE
fix: finish-release gh checkout + Start Release CI dispatch

### DIFF
--- a/.github/workflows/finish-release.yml
+++ b/.github/workflows/finish-release.yml
@@ -26,6 +26,8 @@ jobs:
       startsWith(github.event.workflow_run.head_branch, 'release/')
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Extract version from branch
         id: meta
         run: |

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   create-release-branch:
@@ -96,6 +97,15 @@ jobs:
           git add CHANGELOG.md pyproject.toml uv.lock
           git commit -m "chore(release): prepare ${VERSION}"
           git push -u origin "release/${VERSION}"
+
+      - name: Trigger release branch CI
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # GITHUB_TOKEN pushes do not trigger other workflows; dispatch explicitly.
+          gh workflow run release-branch-ci-dev --ref "release/${VERSION}"
+          echo "✓ Triggered release-branch-ci-dev on release/${VERSION}" >> $GITHUB_STEP_SUMMARY
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary
- This is so that we can have automated releases. Right now, we're able to start a release, and run integration, but finish has been having `gh` syntax errors (this action opens up two PRs from bots, so it's more complex than the other two).
- This PR hopefully cleans that up along with ensuring that starting a release immediately triggers the integration test action and then once integration test succeeds that triggers the finish action.
- **Finish Release:** restore `actions/checkout` in `open-release-pr` so `gh pr create` has a git repo (fixes `fatal: not a git repository` on 1.4.7)
- **Start Release:** after pushing `release/X.Y.Z`, explicitly dispatch `release-branch-ci-dev` — bot pushes via `GITHUB_TOKEN` do not trigger other workflows

## Test plan
- [ ] Merge to `develop`, then sync to `main` (Finish Release reads workflow from default branch)
- [ ] Run Start Release on a patch version and confirm `release-branch-ci-dev` starts automatically
- [ ] Confirm Finish Release opens the release PR after CI passes