### PR TITLE
fix(release-automation): dispatch Finish Release from release CI

### DIFF
--- a/.github/workflows/finish-release.yml
+++ b/.github/workflows/finish-release.yml
@@ -1,9 +1,14 @@
 name: Finish Release
 
 on:
-  workflow_run:
-    workflows: ["release-branch-ci-dev"]
-    types: [completed]
+  # Dispatched by release-branch-ci-dev after successful CI.
+  # workflow_dispatch (unlike workflow_run) is allowed when the caller uses GITHUB_TOKEN.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 1.4.8)'
+        required: true
+        type: string
 
   pull_request:
     types: [closed]
@@ -14,27 +19,26 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: finish-release-${{ github.event_name }}-${{ github.event.workflow_run.head_branch || github.event.pull_request.head.ref || github.run_id }}
+  group: finish-release-${{ github.event_name }}-${{ github.event.inputs.version || github.event.pull_request.head.ref || github.run_id }}
   cancel-in-progress: false
 
 jobs:
   open-release-pr:
     name: Open PR release -> main
-    if: >
-      github.event_name == 'workflow_run' &&
-      github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_branch, 'release/')
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Extract version from branch
+      - name: Extract version from input
         id: meta
+        env:
+          VERSION_INPUT: ${{ github.event.inputs.version }}
         run: |
           set -euo pipefail
-          BR="${{ github.event.workflow_run.head_branch }}"   # release/0.1.9
-          VER="${BR#release/}"                                # 0.1.9
-          [[ "$VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || (echo "Bad release branch: $BR" && exit 1)
+          VER="${VERSION_INPUT#v}"
+          [[ "$VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || (echo "Bad version: $VERSION_INPUT" && exit 1)
+          BR="release/${VER}"
           echo "branch=$BR" >> $GITHUB_OUTPUT
           echo "version=$VER" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -14,6 +14,10 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+  actions: write
+
 concurrency:
   group: release-branch-ci-dev-${{ github.ref }}
   cancel-in-progress: false
@@ -31,6 +35,7 @@ jobs:
     outputs:
       run_integration: ${{ steps.classify.outputs.run_integration }}
       bump_type: ${{ steps.classify.outputs.bump_type }}
+      version: ${{ steps.classify.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
@@ -75,6 +80,7 @@ jobs:
           print(bump, str(run).lower())
           ")"
 
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
           echo "bump_type=$BUMP" >> "$GITHUB_OUTPUT"
           echo "run_integration=$RUN" >> "$GITHUB_OUTPUT"
 
@@ -274,3 +280,26 @@ jobs:
             --var "datakind_notification_email=${{ secrets.DATAKIND_EMAIL }}" \
             --var "DK_CC_EMAIL=${{ secrets.DATAKIND_EMAIL }}" \
             --params "model_name=$MODEL_NAME,config_file_name=$CONFIG_FILE,job_type=inference,schema_type=edvise,is_genai_institution=true,db_run_id=${DB_RUN_ID_PREFIX}_es_inference"
+
+  trigger-finish-release:
+    name: Trigger Finish Release
+    needs: [classify-release, pdp-integration, es-integration]
+    # Run when classify succeeded and any required integration jobs succeeded or were skipped (patch).
+    if: >
+      always() &&
+      needs.classify-release.result == 'success' &&
+      (needs.pdp-integration.result == 'success' || needs.pdp-integration.result == 'skipped') &&
+      (needs.es-integration.result == 'success' || needs.es-integration.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Finish Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.classify-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          BR="release/${VERSION}"
+          # Use this release branch as --ref so the Finish Release YAML present on the
+          # release branch is used (GITHUB_TOKEN may dispatch workflow_dispatch).
+          gh workflow run "Finish Release" --ref "$BR" -f version="$VERSION"
+          echo "✓ Triggered Finish Release for $BR" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -114,5 +114,5 @@ jobs:
           echo "✓ Version metadata updated" >> $GITHUB_STEP_SUMMARY
           echo "✓ Release branch pushed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Next step:** Once release CI completes, Finish Release will open PRs automatically." >> $GITHUB_STEP_SUMMARY
+          echo "**Next step:** Once release CI completes, it will dispatch Finish Release to open the release PR." >> $GITHUB_STEP_SUMMARY
 

--- a/tests/utils/test_release_automation.py
+++ b/tests/utils/test_release_automation.py
@@ -854,16 +854,11 @@ class TestWorkflowConditions:
         assert not automate_releases.should_run_release_integration("1.4.6", "1.4.5")
 
     def test_release_pr_condition(self):
-        """Test condition for opening release PR after CI."""
-        event_name = "workflow_run"
-        conclusion = "success"
-        branch = "release/0.1.9"
+        """Test condition for opening release PR via Finish Release dispatch."""
+        event_name = "workflow_dispatch"
+        version = "0.1.9"
 
-        should_trigger = (
-            event_name == "workflow_run"
-            and conclusion == "success"
-            and branch.startswith("release/")
-        )
+        should_trigger = event_name == "workflow_dispatch" and bool(version)
 
         assert should_trigger
 
@@ -975,11 +970,14 @@ class TestWorkflowYAMLSyntax:
 
         on_section = workflow.get(True) or workflow.get("on")
         assert on_section is not None
-        assert "workflow_run" in on_section
+        assert "workflow_dispatch" in on_section
+        assert "version" in on_section["workflow_dispatch"]["inputs"]
+        assert "workflow_run" not in on_section
         assert "pull_request" in on_section
         assert "open-release-pr" in workflow["jobs"]
         assert "tag-and-open-backmerge-pr" in workflow["jobs"]
         assert "delete-release-branch" in workflow["jobs"]
+        assert "workflow_dispatch" in workflow["jobs"]["open-release-pr"]["if"]
 
     def test_release_integration_workflow_yaml(self):
         """Test release-integration.yml gates integration on bump type."""
@@ -997,11 +995,15 @@ class TestWorkflowYAMLSyntax:
         assert "workflow_dispatch" in on_section
         assert "force_integration" in on_section["workflow_dispatch"]["inputs"]
 
+        assert workflow["permissions"]["actions"] == "write"
+
         jobs = workflow["jobs"]
         assert "classify-release" in jobs
         assert jobs["classify-release"]["outputs"]["run_integration"]
         assert jobs["classify-release"]["outputs"]["bump_type"]
-        assert "finish-release" not in jobs
+        assert jobs["classify-release"]["outputs"]["version"]
+        assert "trigger-finish-release" in jobs
+        assert "Finish Release" in jobs["trigger-finish-release"]["steps"][-1]["run"]
 
         for job_name in ("pdp-integration", "es-integration"):
             job = jobs[job_name]
@@ -1016,6 +1018,7 @@ class TestWorkflowYAMLSyntax:
         workflows = [
             "start-release.yml",
             "finish-release.yml",
+            "release-integration.yml",
         ]
 
         for workflow_file in workflows:
@@ -1029,12 +1032,16 @@ class TestWorkflowYAMLSyntax:
             if workflow_file == "start-release.yml":
                 assert "contents" in workflow["permissions"]
                 assert workflow["permissions"]["contents"] == "write"
+                assert workflow["permissions"]["actions"] == "write"
 
             if workflow_file == "finish-release.yml":
                 assert "contents" in workflow["permissions"]
                 assert workflow["permissions"]["contents"] == "write"
                 assert "pull-requests" in workflow["permissions"]
                 assert workflow["permissions"]["pull-requests"] == "write"
+
+            if workflow_file == "release-integration.yml":
+                assert workflow["permissions"]["actions"] == "write"
 
     def test_workflow_job_structure(self):
         """Test that finish-release workflow jobs have required structure."""


### PR DESCRIPTION
## Summary
- Replace Finish Release `workflow_run` trigger with `workflow_dispatch` (`version` input) so it can be started with `GITHUB_TOKEN`.
- Have `release-branch-ci-dev` dispatch Finish Release after classify (+ optional PDP/ES) succeeds or is skipped for patches.
- Give release CI `actions: write` and export `version` from classify.

`workflow_run` never woke when Start Release dispatched CI as `github-actions[bot]`. Explicit `workflow_dispatch` is exempt from that cascade block (same pattern as Start Release → release CI).

## Notes
- Finish Release must land on **main** before `gh workflow run "Finish Release"` works end-to-end (GitHub only dispatches workflows present on the default branch). `--ref release/X.Y.Z` then selects that branch’s YAML once registered.
- Tag / back-merge / branch-delete jobs are unchanged (`pull_request` closed).

## Test plan
- [ ] Merge to `develop`, get these workflow files onto `main` (next release with a manual open-PR step, or a workflows-only PR)
- [ ] Run Start Release from `develop` for a patch version
- [ ] Confirm release CI’s **Trigger Finish Release** job succeeds
- [ ] Confirm Finish Release opens `release/X.Y.Z` → `main`
- [ ] Merge release PR; confirm tag + back-merge PR still work


Made with [Cursor](https://cursor.com)