### PR TITLE
fix(genai): SMA prompt improvements with program type vs major column discrimination

### DIFF
--- a/src/edvise/genai/mapping/schema_mapping_agent/manifest/prompts/generate.py
+++ b/src/edvise/genai/mapping/schema_mapping_agent/manifest/prompts/generate.py
@@ -48,12 +48,17 @@ _RAW_EDVISE_STUDENT_FIELD_SEMANTIC_NOTES: dict[str, str] = {
         "not term-level status."
     ),
     "intended_program_type": (
-        "Cohort entry snapshot: program or credential the student intended to pursue when "
-        "entering (aligned with entry_year/entry_term). Not the current/latest primary program."
+        "Cohort entry snapshot: credential / program TYPE at entry (certificate, associate, "
+        "bachelor's, etc.) — aligned with entry_year/entry_term. Prefer a degree/credential "
+        "code or short type label (e.g. AA, AS, AAS, Bachelor's, Certificate). NOT an academic "
+        "plan / major description, NOT a field-of-study name, and NOT the current/latest program. "
+        "Distinct from declared_major_at_entry (major / plan text)."
     ),
     "declared_major_at_entry": (
-        "Cohort entry snapshot: declared major (or primary field of study) at program entry. "
-        "Not the latest major row from longitudinal history or current major."
+        "Cohort entry snapshot: declared major (or primary field of study / academic plan) at "
+        "program entry. Prefer major, plan, or program-of-study description columns — NOT a "
+        "degree/credential type code used for intended_program_type. Not the latest major row "
+        "from longitudinal history or current major."
     ),
     "major_at_completion": (
         "Outcome: field of study at completion/exit — distinct from declared_major_at_entry."
@@ -109,13 +114,18 @@ _RAW_EDVISE_COURSE_FIELD_SEMANTIC_NOTES: dict[str, str] = {
         "an ordinal sort key. Use _term_order for chronological sorting."
     ),
     "term_degree": (
-        "Term snapshot: degree level the student is pursuing IN THIS TERM (e.g. UG / GR, "
-        "Associate / Bachelors). Not the credential conferred at exit (conferred_credential_type) "
-        "and not the cohort intended_program_type."
+        "Term snapshot: degree / credential LEVEL or TYPE the student is pursuing IN THIS TERM "
+        "(e.g. UG / GR, Associate / Bachelors, AA, AS, Certificate). Prefer a degree/credential "
+        "code or short level label. NOT an academic plan / major description and NOT academic "
+        "standing alone when a clearer degree-sought column exists. Not the credential conferred "
+        "at exit (conferred_credential_type), not cohort intended_program_type, and distinct from "
+        "term_declared_major (major / plan text this term)."
     ),
     "term_declared_major": (
-        "Term snapshot: declared major IN THIS TERM. Distinct from cohort "
-        "declared_major_at_entry (entry-time) and major_at_completion (outcome)."
+        "Term snapshot: declared major / field of study / academic plan IN THIS TERM. Prefer "
+        "major, plan, or program-of-study description columns — NOT a degree/credential type "
+        "code used for term_degree. Distinct from cohort declared_major_at_entry (entry-time) "
+        "and major_at_completion (outcome)."
     ),
     "term_pell_recipient": (
         "Term-level Pell receipt for THIS term enrollment. Distinct from cohort-level "
@@ -384,9 +394,64 @@ These fields describe the student **at cohort/program entry** (same conceptual m
 - Do **not** map these targets from **`major_at_completion`** sources or other completion/exit fields.
 - `major_at_completion` is outcome semantics and belongs only on that target.
 
-**(5) Unmappable**
+**(5) Credential TYPE vs major / plan (REQUIRED column-kind check)**
+These two targets are related but **not interchangeable**. Inspect column names **and**
+`unique_values` / `sample_values` before assigning either field.
+
+- **`intended_program_type`** = credential / program **type** (certificate vs associate vs
+  bachelor's, etc.). Prefer columns named or defined as **degree**, **credential**,
+  **award type**, **program type**, or **degree sought**, whose values are short type codes
+  or labels (e.g. `AA`, `AS`, `AAS`, `BA`, `BS`, `Certificate`, `Associate`, `Bachelor's`).
+- **`declared_major_at_entry`** = **field of study** (major, concentration, academic plan /
+  plan description, program-of-study name). Prefer columns named or defined as **major**,
+  **plan**, **acad_plan**, **program of study**, or similar, whose values name disciplines
+  or plans (e.g. `AS Biology - Health Sciences`, `AA Business`, `Nursing`).
+- **Do not** map an academic-plan / major-description column to `intended_program_type` when a
+  clearer degree/credential-type column exists on a usable table (even if plan text embeds
+  phrases like "Associate in Arts").
+- **Do not** map a pure degree/credential-type code column to `declared_major_at_entry` when a
+  major/plan description column exists.
+- Prefer **different** source columns for the two targets when both are present. Reusing one
+  column for both is allowed only when no better type-vs-major split exists — state that in
+  **validation_notes** and use **confidence ≤ {t}** with HITL.
+- Do **not** invent value remapping to "Edvise categories" in rationale: Step 2b preserves
+  institution source wording for these fields (`map_values` is forbidden).
+
+**(6) Unmappable**
 - Prefer unmappable (per UNMAPPABLE FIELDS) over forcing **latest** or **completion** data into
-  `intended_program_type` or `declared_major_at_entry`.
+  `intended_program_type` or `declared_major_at_entry`, and over forcing a major/plan column into
+  `intended_program_type` when no defensible degree/type source exists.
+"""
+
+
+def _step2a_course_term_degree_and_major_rules() -> str:
+    """Step 2a: term_degree vs term_declared_major — type/level vs field of study."""
+    t = PIPELINE_HITL_CONFIDENCE_THRESHOLD
+    return f"""
+COURSE term_degree AND term_declared_major — type/level vs field-of-study
+
+These course targets are **term snapshots** (value on the enrollment / course row for THIS term).
+They are related but **not interchangeable**. Inspect column names **and** `unique_values` /
+`sample_values` before assigning either field.
+
+- **`term_degree`** = degree / credential **level or type** pursued in this term (e.g. UG / GR,
+  Associate / Bachelors, `AA`, `AS`, `Certificate`). Prefer columns named or defined as
+  **degree**, **credential**, **award type**, **degree level**, or **program type**.
+- **`term_declared_major`** = **field of study** declared in this term (major, concentration,
+  academic plan / plan description). Prefer **major**, **plan**, **acad_plan**, or
+  program-of-study description columns.
+- **Do not** map an academic-plan / major-description column to `term_degree` when a clearer
+  degree/level/type column exists (even if plan text embeds "Associate…" / "Bachelor…").
+- **Do not** map a pure degree/credential-type code column to `term_declared_major` when a
+  major/plan description column exists.
+- Prefer **different** source columns when both targets are mapped. Reusing one column for
+  both is allowed only when no better split exists — state that in **validation_notes** and
+  use **confidence ≤ {t}** with HITL.
+- `term_degree` is **not** `conferred_credential_type` (exit award) and **not** cohort
+  `intended_program_type` (entry snapshot). `term_declared_major` is **not** cohort
+  `declared_major_at_entry` (entry) or `major_at_completion` (outcome).
+- Do **not** invent value remapping to canonical categories in rationale: Step 2b preserves
+  institution source wording for these fields (`map_values` is forbidden).
 """
 
 
@@ -488,9 +553,10 @@ def _step2a_rules_after_structure(
 ) -> str:
     """Shared rules (SOURCE COLUMNS → TARGET SCHEMA AUTHORITY) for all Step 2a prompt variants.
 
-    ``term_rules`` controls which term-field hierarchies are injected (cohort entry vs course academic):
-    ``cohort_and_course`` for single-pass prompts;     ``cohort_only`` / ``course_only`` for entity passes
-    so each pass only sees instructions for its entity.
+    ``term_rules`` controls which field hierarchies are injected:
+    ``cohort_and_course`` for single-pass / batched prompts (cohort entry + course academic +
+    type-vs-major rules for both entities); ``cohort_only`` / ``course_only`` for entity passes
+    so each pass only sees instructions for its entity (including the matching type-vs-major block).
     """
     pipeline_hitl_t = PIPELINE_HITL_CONFIDENCE_THRESHOLD
     alias_bullet = _column_aliases_scope_bullet(column_aliases_scope)
@@ -500,6 +566,7 @@ def _step2a_rules_after_structure(
             + _step2a_cohort_entry_program_and_major_rules()
             + _step2a_cohort_degree_conferral_datetime_rules()
             + _step2a_course_academic_term_rules()
+            + _step2a_course_term_degree_and_major_rules()
         )
     elif term_rules == "cohort_only":
         term_blocks = (
@@ -508,7 +575,11 @@ def _step2a_rules_after_structure(
             + _step2a_cohort_degree_conferral_datetime_rules()
         )
     else:
-        term_blocks = _step2a_course_academic_term_rules()
+        # course_only entity pass — do not inject cohort program/major rules
+        term_blocks = (
+            _step2a_course_academic_term_rules()
+            + _step2a_course_term_degree_and_major_rules()
+        )
 
     return f"""SOURCE COLUMNS
 - Use only source columns and tables present in the {institution_id} schema contract

--- a/src/edvise/genai/mapping/schema_mapping_agent/manifest/prompts/refine.py
+++ b/src/edvise/genai/mapping/schema_mapping_agent/manifest/prompts/refine.py
@@ -405,6 +405,26 @@ When the manifest section is **cohort** (student / RawEdviseStudentDataSchema):
   apply **refined_by_llm** / **refined_and_proposed_for_hitl** or **proposed_for_hitl** as appropriate.
 - Never use **`major_at_completion`** mapping logic for **`declared_major_at_entry`** unless the
   source column is provably entry-time (unusual).
+- **Column kind:** `intended_program_type` is credential / program **type** (degree/credential codes
+  or short type labels). `declared_major_at_entry` is **field of study** (major / academic plan /
+  plan description). Mapping a plan/major description to `intended_program_type` when a clearer
+  degree/type column exists — or a pure degree code to `declared_major_at_entry` when a major/plan
+  column exists — is a **semantic error**. Prefer distinct source columns for the two targets.
+"""
+
+_COURSE_TARGET_SEMANTICS_FOR_REFINEMENT = """
+## Course target semantics (RawEdviseCourseDataSchema)
+
+When the manifest section is **course** (RawEdviseCourseDataSchema):
+
+- **`term_degree`** is the degree / credential **level or type** pursued **in this term**.
+  **`term_declared_major`** is the **field of study / academic plan** in this term.
+- Mapping a plan/major description to `term_degree` when a clearer degree/level/type column exists —
+  or a pure degree code to `term_declared_major` when a major/plan column exists — is a
+  **semantic error**. Prefer distinct source columns for the two targets.
+- Do not treat `term_degree` as cohort `intended_program_type` or exit `conferred_credential_type`,
+  and do not treat `term_declared_major` as cohort `declared_major_at_entry` or
+  `major_at_completion`.
 """
 
 _COHORT_SEMANTICS_PASS2 = """
@@ -415,6 +435,20 @@ favor **entry / admit / first-term** sources. If the flagged mapping used **curr
 major/program semantics, option 1 should normally be the entry-aligned alternative; describe any
 remaining proxy honestly. Options for **`major_at_completion`** must not be reused as substitutes
 for **`declared_major_at_entry`** unless the column meaning supports entry time.
+
+For **`intended_program_type`**, prefer degree/credential-type columns over academic-plan / major
+description columns when both exist. For **`declared_major_at_entry`**, prefer major/plan columns
+over pure degree-type codes when both exist.
+"""
+
+_COURSE_SEMANTICS_PASS2 = """
+## Course term_degree vs term_declared_major (Pass 2 options)
+
+For flags on **`term_degree`**, TERMINAL options should prefer degree/credential **level or type**
+columns over academic-plan / major description columns when both exist. For flags on
+**`term_declared_major`**, prefer major/plan / field-of-study columns over pure degree-type codes
+when both exist. Option 1 should normally be the column-kind-correct alternative when the flagged
+mapping swapped type vs major.
 """
 
 _PASS1_OUTPUT_FORMAT = """
@@ -485,6 +519,8 @@ generating options (that is Pass 2).
 
 {_COHORT_TARGET_SEMANTICS_FOR_REFINEMENT}
 
+{_COURSE_TARGET_SEMANTICS_FOR_REFINEMENT}
+
 ## Output format
 
 {output_format}
@@ -532,6 +568,8 @@ escape hatch on every item.
 {_FIELD_COLLAPSE_RULE}
 
 {_COHORT_SEMANTICS_PASS2}
+
+{_COURSE_SEMANTICS_PASS2}
 
 CRITICAL — current_field_mapping:
   current_field_mapping in each item must be copied unchanged from the corresponding Pass 1 hitl_flag.

--- a/tests/genai/mapping/schema_mapping_agent/manifest/test_prompts_step2a_batched.py
+++ b/tests/genai/mapping/schema_mapping_agent/manifest/test_prompts_step2a_batched.py
@@ -7,7 +7,12 @@ from edvise.data_audit.schemas.raw_edvise_student import RawEdviseStudentDataSch
 from edvise.genai.mapping.schema_mapping_agent.manifest.prompts import (
     audit_step2a_batched_prompt,
     audit_step2a_prompt,
+    build_refinement_pass1_system_prompt,
+    build_refinement_pass2_system_prompt,
     build_step2a_batched_prompt,
+    build_step2a_prompt_cohort_pass,
+    build_step2a_prompt_course_pass,
+    extract_schema_descriptor,
 )
 
 
@@ -125,3 +130,55 @@ def test_audit_step2a_batched_prompt_section_breakdown():
         "rules",
     }
     assert out["total_estimated_tokens"] == sum(out["sections"].values())
+
+
+def _shared_prompt_kwargs() -> dict:
+    return dict(
+        institution_id="test_cc",
+        output_path="s3://bucket/manifest.json",
+        institution_schema_contract=_minimal_institution_schema_contract(),
+        reference_manifests=[_minimal_reference_manifest()],
+    )
+
+
+def test_cohort_pass_includes_type_vs_major_rules_not_course_degree_rules():
+    text = build_step2a_prompt_cohort_pass(
+        **_shared_prompt_kwargs(),
+        cohort_schema_class=RawEdviseStudentDataSchema,
+    )
+    assert "Credential TYPE vs major / plan" in text
+    assert "intended_program_type" in text
+    assert "declared_major_at_entry" in text
+    assert "COURSE term_degree AND term_declared_major" not in text
+
+
+def test_course_pass_includes_term_degree_vs_major_rules_not_cohort_program_rules():
+    text = build_step2a_prompt_course_pass(
+        **_shared_prompt_kwargs(),
+        course_schema_class=RawEdviseCourseDataSchema,
+    )
+    assert "COURSE term_degree AND term_declared_major" in text
+    assert "COHORT intended_program_type AND declared_major_at_entry" not in text
+
+
+def test_schema_descriptor_notes_separate_type_from_major():
+    student = extract_schema_descriptor(RawEdviseStudentDataSchema)
+    course = extract_schema_descriptor(RawEdviseCourseDataSchema)
+    ipt = student["fields"]["intended_program_type"]["semantic_note"]
+    major = student["fields"]["declared_major_at_entry"]["semantic_note"]
+    term_deg = course["fields"]["term_degree"]["semantic_note"]
+    term_maj = course["fields"]["term_declared_major"]["semantic_note"]
+    assert "credential / program TYPE" in ipt
+    assert "NOT an academic plan" in ipt
+    assert "NOT a degree/credential type code" in major
+    assert "degree / credential LEVEL or TYPE" in term_deg
+    assert "NOT a degree/credential type code" in term_maj
+
+
+def test_refinement_prompts_include_cohort_and_course_type_vs_major_rules():
+    pass1 = build_refinement_pass1_system_prompt()
+    pass2 = build_refinement_pass2_system_prompt()
+    assert "Column kind:" in pass1
+    assert "term_degree" in pass1 and "term_declared_major" in pass1
+    assert "prefer degree/credential-type columns" in pass2
+    assert "Course term_degree vs term_declared_major" in pass2


### PR DESCRIPTION
## Description
- Came up for a school where there was an issue with SMA mapping program type vs. major with the wrong semantic meaning.

## Asana Task
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216577546725556?focus=true

## Deployment Readiness\*

### Testing

Describe or check:

- [ ] Created or updated unit, feature, and/or integration tests  
- [ ] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [ ]  No special deployment steps required

### Rollback Plan

Describe or check:

- [ ]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*

## SOC 2 Change Management Checklist

- [ ] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional