### PR TITLE
fix: coerce both ES course credit columns to Float64

### DIFF
--- a/src/edvise/data_audit/schemas/raw_edvise_course.py
+++ b/src/edvise/data_audit/schemas/raw_edvise_course.py
@@ -9,6 +9,7 @@ validation rules. Column names and checks align with the JSON spec and the
 DataKind course file requirements.
 """
 
+import functools as ft
 import typing as t
 
 import pandas as pd
@@ -64,7 +65,8 @@ ALLOWED_LETTER_GRADES = {
 }
 
 
-CreditsField = pda.Field(nullable=False, ge=0.0)
+# partial so each column gets its own Field (shared Field only coerces the last column)
+CreditsField = ft.partial(pda.Field, nullable=False, ge=0.0)
 
 # Manifest + SMA execution: these target keys must map (ENTITY_GRAIN in
 # manifest.validation). ``course_section_id`` / ``source_term_key`` are optional
@@ -183,8 +185,8 @@ class RawEdviseCourseDataSchema(pda.DataFrameModel):
         description="Catalog section when available; optional when not provided by the institution.",
     )
     grade: pt.Series[pd.StringDtype] = pda.Field(nullable=False)
-    course_credits_attempted: pt.Series[pd.Float64Dtype] = CreditsField
-    course_credits_earned: pt.Series[pd.Float64Dtype] = CreditsField
+    course_credits_attempted: pt.Series[pd.Float64Dtype] = CreditsField()
+    course_credits_earned: pt.Series[pd.Float64Dtype] = CreditsField()
 
     # ------------------------------------------------------------------ #
     # Optional (column may be missing; when present, validated)

--- a/src/edvise/data_audit/schemas/raw_edvise_course.py
+++ b/src/edvise/data_audit/schemas/raw_edvise_course.py
@@ -65,7 +65,6 @@ ALLOWED_LETTER_GRADES = {
 }
 
 
-# partial so each column gets its own Field (shared Field only coerces the last column)
 CreditsField = ft.partial(pda.Field, nullable=False, ge=0.0)
 
 # Manifest + SMA execution: these target keys must map (ENTITY_GRAIN in

--- a/src/edvise/data_audit/schemas/raw_edvise_student.py
+++ b/src/edvise/data_audit/schemas/raw_edvise_student.py
@@ -9,6 +9,7 @@ validation rules. Column names and checks align with the JSON spec and the
 DataKind cohort file requirements.
 """
 
+import functools as ft
 import typing as t
 
 import pandas as pd
@@ -34,7 +35,7 @@ from edvise.data_audit.schemas._edvise_shared import (
 
 PellYesNoField = pda.Field(nullable=True, isin=["Y", "Yes", "N", "No"])
 # When present, values should be >= 0 (ge=0.0). Enforced where supported by Pandera.
-CreditsEarnedField = pda.Field(nullable=True, ge=0.0)
+CreditsEarnedField = ft.partial(pda.Field, nullable=True, ge=0.0)
 
 
 class RawEdviseStudentDataSchema(pda.DataFrameModel):
@@ -115,9 +116,9 @@ class RawEdviseStudentDataSchema(pda.DataFrameModel):
     certificate1_date: t.Optional[pt.Series[pt.DateTime]] = pda.Field(nullable=True)
     certificate2_date: t.Optional[pt.Series[pt.DateTime]] = pda.Field(nullable=True)
     certificate3_date: t.Optional[pt.Series[pt.DateTime]] = pda.Field(nullable=True)
-    credits_earned_ap: t.Optional[pt.Series[pd.Float64Dtype]] = CreditsEarnedField
+    credits_earned_ap: t.Optional[pt.Series[pd.Float64Dtype]] = CreditsEarnedField()
     credits_earned_dual_enrollment: t.Optional[pt.Series[pd.Float64Dtype]] = (
-        CreditsEarnedField
+        CreditsEarnedField()
     )
 
     @classmethod

--- a/tests/data_audit/test_edvise_schemas.py
+++ b/tests/data_audit/test_edvise_schemas.py
@@ -342,6 +342,17 @@ def test_raw_edvise_student_schema_gender_many_distinct_values_passes() -> None:
     assert len(validated_df) == 6
 
 
+def test_raw_edvise_course_schema_coerces_both_credit_columns_to_float64() -> None:
+    """Both credit cols coerce to Float64 (shared Field only coerced the last one)."""
+    row = _minimal_valid_course_row()
+    df = pd.DataFrame([row]).reindex(columns=COURSE_COLUMNS)
+    df["course_credits_attempted"] = pd.Series(["3.0"], dtype="string")
+    df["course_credits_earned"] = pd.Series(["3.0"], dtype="string")
+    validated = RawEdviseCourseDataSchema.validate(df, lazy=True)
+    assert str(validated["course_credits_attempted"].dtype) == "Float64"
+    assert str(validated["course_credits_earned"].dtype) == "Float64"
+
+
 def test_raw_edvise_course_schema_empty_dataframe_passes() -> None:
     """Empty DataFrame with all schema columns passes."""
     df = pd.DataFrame(columns=COURSE_COLUMNS)


### PR DESCRIPTION
Shared pda.Field on course_credits_attempted/earned only coerces the last column, leaving attempted as object/string in silver and breaking frac_credits_earned.

Now, we use ft.partial, following precedent set with PDP, so both columns are coerced to Float64 properly.

Unit tests to ensure works properly. 

Tested on dev.

## Description

## Asana Task
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216604690348111

## Deployment Readiness\*

### Testing

Describe or check:

- [x] Created or updated unit, feature, and/or integration tests  
- [x] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [ ]  No special deployment steps required

### Rollback Plan

Describe or check:

- [ ]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional