### PR TITLE
fix: cap incomplete feature threshold at 20 percent

### DIFF
--- a/src/edvise/configs/es.py
+++ b/src/edvise/configs/es.py
@@ -444,9 +444,29 @@ class FeatureSelectionConfig(pyd.BaseModel):
     """
 
     force_include_cols: t.Optional[list[str]] = None
-    incomplete_threshold: float = 0.5
+    incomplete_threshold: float = pyd.Field(
+        default=0.2,
+        description=(
+            "Max fraction of nulls allowed for a feature to be kept. "
+            "Config may set a stricter (lower) value; values above 0.2 are capped."
+        ),
+    )
     low_variance_threshold: float = 0.0
     collinear_threshold: t.Optional[float] = 10.0
+
+    @pyd.field_validator("incomplete_threshold", mode="after")
+    @classmethod
+    def _cap_incomplete_threshold(cls, value: float) -> float:
+        max_threshold = 0.2
+        if value > max_threshold:
+            warnings.warn(
+                f"incomplete_threshold={value} exceeds max {max_threshold}; "
+                "capping for feature selection",
+                UserWarning,
+                stacklevel=2,
+            )
+            return max_threshold
+        return value
 
 
 class TrainingConfig(pyd.BaseModel):

--- a/src/edvise/configs/legacy.py
+++ b/src/edvise/configs/legacy.py
@@ -544,9 +544,29 @@ class FeatureSelectionConfig(pyd.BaseModel):
     """
 
     force_include_cols: t.Optional[list[str]] = None
-    incomplete_threshold: float = 0.5
+    incomplete_threshold: float = pyd.Field(
+        default=0.2,
+        description=(
+            "Max fraction of nulls allowed for a feature to be kept. "
+            "Config may set a stricter (lower) value; values above 0.2 are capped."
+        ),
+    )
     low_variance_threshold: float = 0.0
     collinear_threshold: t.Optional[float] = 10.0
+
+    @pyd.field_validator("incomplete_threshold", mode="after")
+    @classmethod
+    def _cap_incomplete_threshold(cls, value: float) -> float:
+        max_threshold = 0.2
+        if value > max_threshold:
+            warnings.warn(
+                f"incomplete_threshold={value} exceeds max {max_threshold}; "
+                "capping for feature selection",
+                UserWarning,
+                stacklevel=2,
+            )
+            return max_threshold
+        return value
 
 
 class TrainingConfig(pyd.BaseModel):

--- a/src/edvise/configs/pdp.py
+++ b/src/edvise/configs/pdp.py
@@ -381,9 +381,29 @@ class FeatureSelectionConfig(pyd.BaseModel):
     """
 
     force_include_cols: t.Optional[list[str]] = None
-    incomplete_threshold: float = 0.5
+    incomplete_threshold: float = pyd.Field(
+        default=0.2,
+        description=(
+            "Max fraction of nulls allowed for a feature to be kept. "
+            "Config may set a stricter (lower) value; values above 0.2 are capped."
+        ),
+    )
     low_variance_threshold: float = 0.0
     collinear_threshold: t.Optional[float] = 10.0
+
+    @pyd.field_validator("incomplete_threshold", mode="after")
+    @classmethod
+    def _cap_incomplete_threshold(cls, value: float) -> float:
+        max_threshold = 0.2
+        if value > max_threshold:
+            warnings.warn(
+                f"incomplete_threshold={value} exceeds max {max_threshold}; "
+                "capping for feature selection",
+                UserWarning,
+                stacklevel=2,
+            )
+            return max_threshold
+        return value
 
 
 class TrainingConfig(pyd.BaseModel):

--- a/src/edvise/modeling/feature_selection.py
+++ b/src/edvise/modeling/feature_selection.py
@@ -10,13 +10,17 @@ from statsmodels.stats.outliers_influence import variance_inflation_factor
 
 LOGGER = logging.getLogger(__name__)
 
+# Max fraction of nulls allowed when keeping a feature. Config may set a stricter
+# (lower) value; values above this cap are clamped for feature selection.
+MAX_INCOMPLETE_THRESHOLD = 0.2
+
 
 def select_features(
     df: pd.DataFrame,
     *,
     non_feature_cols: t.Optional[list[str]] = None,
     force_include_cols: t.Optional[list[str]] = None,
-    incomplete_threshold: float = 0.5,
+    incomplete_threshold: float = MAX_INCOMPLETE_THRESHOLD,
     low_variance_threshold: float = 0.0,
     collinear_threshold: t.Optional[float] = 10.0,
 ) -> pd.DataFrame:
@@ -30,6 +34,7 @@ def select_features(
             be run through the feature selection algorithm. For example, demographics, IDs, outcome variables, etc.
         force_include_cols: list of features to force include in the final dataset.
         incomplete_threshold: Threshold for determining incomplete features.
+            Values above ``MAX_INCOMPLETE_THRESHOLD`` (0.2) are capped.
         low_variance_threshold: Threshold for determining low-variance features.
         collinear_threshold: Threshold for determining collinear features;
             if null, skip this selection step.
@@ -41,6 +46,13 @@ def select_features(
     LOGGER.info("selecting features ...")
     non_feature_cols = non_feature_cols or []
     force_include_cols = force_include_cols or []
+    if incomplete_threshold > MAX_INCOMPLETE_THRESHOLD:
+        LOGGER.warning(
+            "incomplete_threshold=%s exceeds max %s; capping for feature selection",
+            incomplete_threshold,
+            MAX_INCOMPLETE_THRESHOLD,
+        )
+        incomplete_threshold = MAX_INCOMPLETE_THRESHOLD
     LOGGER.info(
         "force including %s columns: %s", len(force_include_cols), force_include_cols
     )
@@ -52,7 +64,6 @@ def select_features(
         # but instead can capture any patterns that may relate to the nulls.
         # If there are non-dummy categorical variables that get dropped here,
         # consider pre-processing into dummy variables for this reason.
-        # TODO: tune this threshold over time?
         .pipe(drop_incomplete_features, threshold=incomplete_threshold)
         # NOTE: only removing features with variance == 0.0 by default
         # since features with low but non-zero variance may still be predictive

--- a/src/edvise/reporting/model_card/h2o_base.py
+++ b/src/edvise/reporting/model_card/h2o_base.py
@@ -1,7 +1,7 @@
 import typing as t
 from abc import abstractmethod
 
-from edvise.modeling import h2o_ml
+from edvise.modeling import feature_selection, h2o_ml
 from edvise.reporting.model_card.base import ModelCard
 from edvise.reporting.utils.types import ModelCardConfig
 import edvise.reporting.utils as reporting_utils
@@ -82,12 +82,16 @@ class H2OModelCard(ModelCard[C]):
             )
 
         fs_cfg = self.cfg.modeling.feature_selection
+        incomplete_threshold = min(
+            fs_cfg.incomplete_threshold,
+            feature_selection.MAX_INCOMPLETE_THRESHOLD,
+        )
 
         return {
             "number_of_features": str(feature_count),
             "collinearity_threshold": str(fs_cfg.collinear_threshold),
             "low_variance_threshold": str(fs_cfg.low_variance_threshold),
-            "incomplete_threshold": as_percent(fs_cfg.incomplete_threshold),
+            "incomplete_threshold": as_percent(incomplete_threshold),
         }
 
     def get_model_plots(self) -> dict[str, str]:

--- a/src/edvise/reporting/model_card/h2o_base.py
+++ b/src/edvise/reporting/model_card/h2o_base.py
@@ -103,6 +103,10 @@ class H2OModelCard(ModelCard[C]):
         Returns:
             A dictionary with plot names and their inline HTML representations.
         """
+        if not self.run_id:
+            raise ValueError(
+                f"Cannot download model plots for '{self.model_name}': run_id is not set."
+            )
         plots = self._get_plot_config()
         return {
             key: reporting_utils.utils.download_artifact(

--- a/tests/modeling/test_feature_selection.py
+++ b/tests/modeling/test_feature_selection.py
@@ -55,6 +55,39 @@ def test_drop_incomplete_features(df, threshold, exp_dropped_cols):
     assert df_result.shape[0] == df.shape[0]
 
 
+def test_select_features_caps_incomplete_threshold(df, caplog):
+    """Values above MAX_INCOMPLETE_THRESHOLD are capped before dropping incompletes."""
+    # partially_incomplete_feature is 40% null; incomplete_feature is 80% null.
+    # Cap at 0.2 => both drop. Without the cap (0.5), only incomplete_feature drops.
+    with caplog.at_level("WARNING"):
+        df_result = fs.select_features(
+            df,
+            non_feature_cols=["id"],
+            force_include_cols=["include_feature"],
+            incomplete_threshold=0.5,
+            low_variance_threshold=0.0,
+            collinear_threshold=None,
+        )
+    dropped = df.columns.difference(df_result.columns).tolist()
+    assert "incomplete_feature" in dropped
+    assert "partially_incomplete_feature" in dropped
+    assert any("capping for feature selection" in msg for msg in caplog.messages)
+
+
+def test_select_features_allows_stricter_incomplete_threshold(df):
+    df_result = fs.select_features(
+        df,
+        non_feature_cols=["id"],
+        force_include_cols=["include_feature"],
+        incomplete_threshold=0.1,
+        low_variance_threshold=0.0,
+        collinear_threshold=None,
+    )
+    dropped = df.columns.difference(df_result.columns).tolist()
+    assert "incomplete_feature" in dropped
+    assert "partially_incomplete_feature" in dropped
+
+
 @pytest.mark.parametrize(
     ["threshold", "exp_dropped_cols"],
     [

--- a/tests/reporting/model_card/test_h2o_model_card.py
+++ b/tests/reporting/model_card/test_h2o_model_card.py
@@ -103,6 +103,25 @@ def test_get_feature_metadata_success(mock_get_features, mock_config, mock_clien
     assert metadata["incomplete_threshold"] == "5"
 
 
+@patch("edvise.reporting.model_card.h2o_base.h2o_ml.inference.get_h2o_used_features")
+def test_get_feature_metadata_caps_incomplete_threshold(
+    mock_get_features, mock_config, mock_client
+):
+    mock_get_features.return_value = ["a"]
+    mock_config.modeling.feature_selection.incomplete_threshold = 0.5
+    card = TestableH2OModelCard(
+        config=mock_config,
+        catalog="catalog",
+        model_name="inst_my_model",
+        mlflow_client=mock_client,
+    )
+    card.model = MagicMock()
+
+    metadata = card.get_feature_metadata()
+
+    assert metadata["incomplete_threshold"] == "20"
+
+
 @patch(
     "edvise.reporting.model_card.h2o_base.h2o_ml.evaluation.extract_number_of_runs_from_model_training"
 )


### PR DESCRIPTION
## Summary
- default incomplete-feature filtering to 20% across ES, PDP, and legacy configs
- cap looser config values at 20% while preserving stricter overrides
- report the effective capped threshold in model cards

## Test plan
- [x] Run feature-selection unit tests
- [x] Run H2O model-card unit tests
- [x] Verify config values above 20% are capped and stricter values remain unchanged

Made with [Cursor](https://cursor.com)