### PR TITLE
feat(genai): add Manifest Explorer page to HITL Streamlit app

### DIFF
--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/Home.py
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/Home.py
@@ -5,6 +5,9 @@ GenAI mapping — Unity Catalog ``hitl_reviews`` HITL reviewer UI (multipage).
   (``hitl_reviews`` table, filters, and per-group silver JSON/UC on one page).
 * **Maps & outputs** — ``pages/2_Maps_and_Outputs.py``: institution dropdown, then **Active** or a **HITL-complete onboard run**,
   with catalog from the environment (not a sidebar field on that page).
+* **Manifest explorer** — ``pages/3_Manifest_Explorer.py``: same institution/run picker, but renders the
+  field mapping manifest as one filterable table joined with source-column stats (enriched schema
+  contract) and HITL status, instead of separate raw-JSON files.
 
 HITL **choice** values live in JSON on the **silver** volume. **IA** / **SMA** write silver JSON
 while the UC group is **pending**; use **HITL Review** for the full flow. See module doc in previous
@@ -37,6 +40,8 @@ from hitl_reviewer.ui.hitl_streamlit import (
     validate_catalog,
 )
 
+MANIFEST_EXPLORER_PAGE = "pages/3_Manifest_Explorer.py"
+
 _HITL_BENCH = "HITL Review"
 
 st.set_page_config(page_title="HITL — home", layout="wide")
@@ -56,6 +61,11 @@ st.page_link(
 st.page_link(
     MAPS_AND_OUTPUTS_PAGE,
     label="Open Maps & outputs (HITL-complete runs + Active)",
+    use_container_width=True,
+)
+st.page_link(
+    MANIFEST_EXPLORER_PAGE,
+    label="Open Manifest explorer (one table: manifest + column stats + HITL status)",
     use_container_width=True,
 )
 

--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/ui/_shared.py
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/ui/_shared.py
@@ -166,6 +166,11 @@ p.hitl-opt-mark { display: block; height: 0; margin: 0 !important; padding: 0 !i
 .hitl-chip-row { display: flex; flex-wrap: wrap; gap: 0.35rem; margin-top: 0.25rem; }
 .hitl-chip { display: inline-block; padding: 0.08rem 0.45rem; border-radius: 999px; font-size: 0.72rem;
   background: rgba(111, 66, 193, 0.12); border: 1px solid rgba(111, 66, 193, 0.28); }
+/* Source value has leading/trailing whitespace in the raw data (e.g. fixed-width CHAR export) —
+   dashed border + monospace so padding (rendered as visible middle dots) is legible, not a display fix. */
+.hitl-chip-padded { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  border-style: dashed !important; background: rgba(217, 119, 6, 0.10) !important;
+  border-color: rgba(217, 119, 6, 0.4) !important; }
 .ia-domain-pill {
   display: inline-block; padding: 0.1rem 0.5rem; border-radius: 999px; font-size: 0.72rem; font-weight: 600;
   background: rgba(16, 185, 129, 0.15); border: 1px solid rgba(16, 185, 129, 0.35); color: rgb(6, 95, 70);

--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/ui/manifest_explorer.py
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/ui/manifest_explorer.py
@@ -263,17 +263,21 @@ def attach_column_stats(df: pd.DataFrame, contract: dict[str, Any] | None) -> pd
         if panel is None:
             return pd.Series({c: None for c in _COLUMN_STATS_COLUMNS})
         chips = panel.get("chip_values") or []
-        preview_cap = 12
+        mode = panel.get("chip_mode", "sample")
+        # No truncation: the enriched schema contract already caps `unique_values` at a sane
+        # cardinality (contract_builder.UNIQUE_VALUES_MAX_CARDINALITY, currently 50) before this
+        # ever reaches the UI, so when chip_mode is "unique" this genuinely is the full distinct
+        # set for the column — show it all rather than an arbitrary further preview cap. Label
+        # explicitly so "unique" (complete) is never confused with "sample" (top 5 by frequency,
+        # not exhaustive) at a glance.
         displayed: list[str] = []
         any_padded = False
-        for v in chips[:preview_cap]:
+        for v in chips:
             disp, had_padding = visualize_value_whitespace(v)
             any_padded = any_padded or had_padding
             displayed.append(disp)
-        preview = ", ".join(displayed)
-        remaining = len(chips) - preview_cap
-        if remaining > 0:
-            preview += f", … (+{remaining} more — see detail panel)"
+        label = f"unique ({len(chips)})" if mode == "unique" else "sample, top 5"
+        preview = f"{label}: " + ", ".join(displayed) if displayed else f"{label}: —"
         return pd.Series(
             {
                 "dtype": panel.get("dtype"),

--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/ui/manifest_explorer.py
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/ui/manifest_explorer.py
@@ -1,0 +1,324 @@
+"""
+Manifest Explorer: one consolidated, filterable table joining the Step 2a field mapping
+manifest (``manifest_map.json``) with source-column stats (from
+``enriched_schema_contract.json``) and HITL review status (``cohort_hitl_manifest.json`` /
+``course_hitl_manifest.json``).
+
+Today a reviewer has to open each of those files separately (see
+``hitl_reviewer.ui.run_artifacts_browser``) and cross-reference target fields and source
+columns by eye. This module assembles them into a single ``pandas.DataFrame`` — one row per
+target field — so the app can render one table instead of several raw-JSON expanders.
+
+Kept free of ``edvise`` package imports (same constraint as
+:mod:`hitl_reviewer.ui.sma.enriched_schema_contract`) so the Databricks app bundle does not
+need the full ``edvise`` install.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from hitl_reviewer.platform.unity_volume_files import read_unity_file_text
+from hitl_reviewer.platform.volume_path_utils import silver_genai_mapping_root
+from hitl_reviewer.ui.sma.enriched_schema_contract import (
+    extract_column_panel_fields,
+    load_json_object_from_text,
+)
+
+# Columns always present on the returned table, even when a source file is missing/unreadable
+# or the manifest is empty — callers can rely on these existing without checking first.
+_HITL_STATUS_COLUMNS: tuple[str, ...] = (
+    "flagged_for_hitl",
+    "hitl_failure_mode",
+    "hitl_resolved",
+    "hitl_question",
+)
+_COLUMN_STATS_COLUMNS: tuple[str, ...] = (
+    "dtype",
+    "null_percentage",
+    "null_count",
+    "unique_count",
+    "sample_values",
+)
+
+
+def genai_mapping_root_uc(institution_id: str, catalog: str) -> str:
+    return silver_genai_mapping_root(
+        str(institution_id).strip(), catalog=str(catalog).strip()
+    )
+
+
+def resolve_explorer_paths(
+    institution_id: str,
+    catalog: str,
+    *,
+    onboard_run_id: str | None,
+) -> dict[str, str]:
+    """
+    Absolute Files-API paths for the artifacts this page joins together.
+
+    ``onboard_run_id`` set → paths under ``runs/onboard/{run_id}/…`` (manifest may be mid-HITL;
+    the two HITL manifest paths may or may not exist depending on run state).
+    ``onboard_run_id`` None → promoted ``active/…`` paths (post-HITL; HITL manifest paths are
+    returned empty since Active has no per-field HITL items).
+    """
+    root = genai_mapping_root_uc(institution_id, catalog)
+    rid = str(onboard_run_id or "").strip()
+    if rid:
+        base = Path(root) / "runs" / "onboard" / rid
+        sma = base / "schema_mapping_agent"
+        ia = base / "identity_agent"
+        return {
+            "manifest_map": str(sma / "manifest_map.json"),
+            "enriched_schema_contract": str(ia / "enriched_schema_contract.json"),
+            "cohort_hitl_manifest": str(sma / "cohort_hitl_manifest.json"),
+            "course_hitl_manifest": str(sma / "course_hitl_manifest.json"),
+        }
+    active = Path(root) / "active"
+    return {
+        "manifest_map": str(active / "manifest_map.json"),
+        "enriched_schema_contract": str(active / "enriched_schema_contract.json"),
+        "cohort_hitl_manifest": "",
+        "course_hitl_manifest": "",
+    }
+
+
+def load_json_object_or_none(abs_path: str) -> dict[str, Any] | None:
+    """``None`` on any read/parse failure (missing file, permissions, not JSON, not an object)."""
+    p = (abs_path or "").strip()
+    if not p:
+        return None
+    try:
+        raw = read_unity_file_text(p)
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        return load_json_object_from_text(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def _join_summary(join: Any) -> str:
+    if not isinstance(join, dict) or not join:
+        return ""
+    bt = join.get("base_table")
+    lt = join.get("lookup_table")
+    jk = join.get("join_keys")
+    jk_s = ", ".join(str(k) for k in jk) if isinstance(jk, list) else str(jk)
+    return f"{bt} ← {lt} on [{jk_s}]"
+
+
+def _row_selection_summary(rs: Any) -> str:
+    if not isinstance(rs, dict) or not rs:
+        return ""
+    parts = [str(rs.get("strategy") or "")]
+    if rs.get("order_by") is not None:
+        parts.append(f"order_by={rs['order_by']}")
+    if rs.get("condition_col") is not None:
+        parts.append(f"condition_col={rs['condition_col']}")
+    if rs.get("n") is not None:
+        parts.append(f"n={rs['n']}")
+    filt = rs.get("filter")
+    if isinstance(filt, dict) and filt.get("column"):
+        parts.append(
+            f"filter: {filt.get('column')} {filt.get('operator')} {filt.get('value')!r}"
+        )
+    return " · ".join(p for p in parts if p)
+
+
+def flatten_manifest_envelope(envelope: dict[str, Any] | None) -> pd.DataFrame:
+    """One row per ``FieldMappingRecord`` across the cohort and course manifests."""
+    rows: list[dict[str, Any]] = []
+    manifests = (envelope or {}).get("manifests") or {}
+    if isinstance(manifests, dict):
+        for entity_type in ("cohort", "course"):
+            manifest = manifests.get(entity_type)
+            if not isinstance(manifest, dict):
+                continue
+            mappings = manifest.get("mappings")
+            if not isinstance(mappings, list):
+                continue
+            for rec in mappings:
+                if not isinstance(rec, dict):
+                    continue
+                rows.append(
+                    {
+                        "entity_type": entity_type,
+                        "target_field": rec.get("target_field"),
+                        "source_table": rec.get("source_table"),
+                        "source_column": rec.get("source_column"),
+                        "join": _join_summary(rec.get("join")),
+                        "row_selection": _row_selection_summary(rec.get("row_selection")),
+                        "confidence": rec.get("confidence"),
+                        "review_status": rec.get("review_status") or "",
+                        "rationale": rec.get("rationale") or "",
+                        "validation_notes": rec.get("validation_notes") or "",
+                        "reviewer_notes": rec.get("reviewer_notes") or "",
+                        "_join_raw": rec.get("join"),
+                        "_row_selection_raw": rec.get("row_selection"),
+                    }
+                )
+    cols = [
+        "entity_type",
+        "target_field",
+        "source_table",
+        "source_column",
+        "join",
+        "row_selection",
+        "confidence",
+        "review_status",
+        "rationale",
+        "validation_notes",
+        "reviewer_notes",
+        "_join_raw",
+        "_row_selection_raw",
+    ]
+    return pd.DataFrame(rows, columns=cols)
+
+
+def _hitl_lookup(hitl_json: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+    """``target_field -> {failure_mode, choice, hitl_question}`` from a cohort/course HITL manifest."""
+    out: dict[str, dict[str, Any]] = {}
+    items = (hitl_json or {}).get("items")
+    if not isinstance(items, list):
+        return out
+    for it in items:
+        if not isinstance(it, dict):
+            continue
+        tf = it.get("target_field")
+        if tf is None:
+            continue
+        out[str(tf)] = {
+            "failure_mode": it.get("failure_mode") or "",
+            "hitl_choice": it.get("choice"),
+            "hitl_question": it.get("hitl_question") or "",
+        }
+    return out
+
+
+def attach_hitl_status(
+    df: pd.DataFrame,
+    *,
+    cohort_hitl: dict[str, Any] | None,
+    course_hitl: dict[str, Any] | None,
+) -> pd.DataFrame:
+    """Adds ``flagged_for_hitl`` / ``hitl_failure_mode`` / ``hitl_resolved`` / ``hitl_question``."""
+    if df.empty:
+        for c in _HITL_STATUS_COLUMNS:
+            df[c] = pd.Series(dtype="object")
+        return df
+    lookups = {"cohort": _hitl_lookup(cohort_hitl), "course": _hitl_lookup(course_hitl)}
+
+    def _row(r: pd.Series) -> pd.Series:
+        lk = lookups.get(str(r["entity_type"]), {})
+        hit = lk.get(str(r["target_field"]))
+        if hit is None:
+            return pd.Series(
+                {
+                    "flagged_for_hitl": False,
+                    "hitl_failure_mode": "",
+                    "hitl_resolved": None,
+                    "hitl_question": "",
+                }
+            )
+        return pd.Series(
+            {
+                "flagged_for_hitl": True,
+                "hitl_failure_mode": hit.get("failure_mode") or "",
+                "hitl_resolved": hit.get("hitl_choice") is not None,
+                "hitl_question": hit.get("hitl_question") or "",
+            }
+        )
+
+    extra = df.apply(_row, axis=1)
+    return pd.concat([df, extra], axis=1)
+
+
+def attach_column_stats(df: pd.DataFrame, contract: dict[str, Any] | None) -> pd.DataFrame:
+    """
+    Joins per-row source-column stats (dtype, null rate, unique count, sample values) from the
+    enriched schema contract. Reuses :func:`extract_column_panel_fields` — the same lookup the
+    per-item SMA HITL panel uses for the single currently-flagged item — applied here to every
+    row so the whole manifest can be reviewed against column quality at once.
+    """
+    if df.empty or not contract:
+        for c in _COLUMN_STATS_COLUMNS:
+            df[c] = pd.Series(dtype="object")
+        return df
+
+    def _row(r: pd.Series) -> pd.Series:
+        table = r.get("source_table")
+        column = r.get("source_column")
+        if not table or not column:
+            return pd.Series({c: None for c in _COLUMN_STATS_COLUMNS})
+        panel = extract_column_panel_fields(
+            contract, dataset_name=str(table), source_column=str(column)
+        )
+        if panel is None:
+            return pd.Series({c: None for c in _COLUMN_STATS_COLUMNS})
+        chips = panel.get("chip_values") or []
+        return pd.Series(
+            {
+                "dtype": panel.get("dtype"),
+                "null_percentage": panel.get("null_percentage"),
+                "null_count": panel.get("null_count"),
+                "unique_count": panel.get("unique_count"),
+                "sample_values": ", ".join(str(c) for c in chips[:12]),
+            }
+        )
+
+    extra = df.apply(_row, axis=1)
+    return pd.concat([df, extra], axis=1)
+
+
+def build_manifest_explorer_table(
+    *,
+    manifest_map_path: str,
+    enriched_schema_contract_path: str,
+    cohort_hitl_manifest_path: str,
+    course_hitl_manifest_path: str,
+) -> tuple[pd.DataFrame, dict[str, bool]]:
+    """
+    Returns ``(table, availability)``. ``availability`` reports which source files were
+    readable so the page can tell the reviewer what's missing rather than silently rendering
+    blank columns.
+    """
+    envelope = load_json_object_or_none(manifest_map_path)
+    contract = load_json_object_or_none(enriched_schema_contract_path)
+    cohort_hitl = load_json_object_or_none(cohort_hitl_manifest_path)
+    course_hitl = load_json_object_or_none(course_hitl_manifest_path)
+
+    df = flatten_manifest_envelope(envelope)
+    df = attach_hitl_status(df, cohort_hitl=cohort_hitl, course_hitl=course_hitl)
+    df = attach_column_stats(df, contract)
+
+    availability = {
+        "manifest_map": envelope is not None,
+        "enriched_schema_contract": contract is not None,
+        "cohort_hitl_manifest": bool(cohort_hitl_manifest_path) and cohort_hitl is not None,
+        "course_hitl_manifest": bool(course_hitl_manifest_path) and course_hitl is not None,
+    }
+    return df, availability
+
+
+def full_column_sample_values(
+    contract: dict[str, Any] | None,
+    *,
+    source_table: str | None,
+    source_column: str | None,
+    limit: int = 80,
+) -> tuple[list[str], str]:
+    """Untruncated (up to ``limit``) chip values + mode ('unique'|'sample') for a detail panel."""
+    if not contract or not source_table or not source_column:
+        return [], "sample"
+    panel = extract_column_panel_fields(
+        contract, dataset_name=str(source_table), source_column=str(source_column)
+    )
+    if panel is None:
+        return [], "sample"
+    chips = panel.get("chip_values") or []
+    return [str(c) for c in chips[:limit]], str(panel.get("chip_mode") or "sample")

--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/ui/manifest_explorer.py
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/ui/manifest_explorer.py
@@ -27,6 +27,7 @@ from hitl_reviewer.platform.volume_path_utils import silver_genai_mapping_root
 from hitl_reviewer.ui.sma.enriched_schema_contract import (
     extract_column_panel_fields,
     load_json_object_from_text,
+    visualize_value_whitespace,
 )
 
 # Columns always present on the returned table, even when a source file is missing/unreadable
@@ -43,6 +44,7 @@ _COLUMN_STATS_COLUMNS: tuple[str, ...] = (
     "null_count",
     "unique_count",
     "sample_values",
+    "has_padded_values",
 )
 
 
@@ -261,13 +263,25 @@ def attach_column_stats(df: pd.DataFrame, contract: dict[str, Any] | None) -> pd
         if panel is None:
             return pd.Series({c: None for c in _COLUMN_STATS_COLUMNS})
         chips = panel.get("chip_values") or []
+        preview_cap = 12
+        displayed: list[str] = []
+        any_padded = False
+        for v in chips[:preview_cap]:
+            disp, had_padding = visualize_value_whitespace(v)
+            any_padded = any_padded or had_padding
+            displayed.append(disp)
+        preview = ", ".join(displayed)
+        remaining = len(chips) - preview_cap
+        if remaining > 0:
+            preview += f", … (+{remaining} more — see detail panel)"
         return pd.Series(
             {
                 "dtype": panel.get("dtype"),
                 "null_percentage": panel.get("null_percentage"),
                 "null_count": panel.get("null_count"),
                 "unique_count": panel.get("unique_count"),
-                "sample_values": ", ".join(str(c) for c in chips[:12]),
+                "sample_values": preview,
+                "has_padded_values": any_padded,
             }
         )
 

--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/ui/manifest_explorer.py
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/ui/manifest_explorer.py
@@ -154,7 +154,9 @@ def flatten_manifest_envelope(envelope: dict[str, Any] | None) -> pd.DataFrame:
                         "source_table": rec.get("source_table"),
                         "source_column": rec.get("source_column"),
                         "join": _join_summary(rec.get("join")),
-                        "row_selection": _row_selection_summary(rec.get("row_selection")),
+                        "row_selection": _row_selection_summary(
+                            rec.get("row_selection")
+                        ),
                         "confidence": rec.get("confidence"),
                         "review_status": rec.get("review_status") or "",
                         "rationale": rec.get("rationale") or "",
@@ -240,7 +242,9 @@ def attach_hitl_status(
     return pd.concat([df, extra], axis=1)
 
 
-def attach_column_stats(df: pd.DataFrame, contract: dict[str, Any] | None) -> pd.DataFrame:
+def attach_column_stats(
+    df: pd.DataFrame, contract: dict[str, Any] | None
+) -> pd.DataFrame:
     """
     Joins per-row source-column stats (dtype, null rate, unique count, sample values) from the
     enriched schema contract. Reuses :func:`extract_column_panel_fields` — the same lookup the
@@ -317,8 +321,10 @@ def build_manifest_explorer_table(
     availability = {
         "manifest_map": envelope is not None,
         "enriched_schema_contract": contract is not None,
-        "cohort_hitl_manifest": bool(cohort_hitl_manifest_path) and cohort_hitl is not None,
-        "course_hitl_manifest": bool(course_hitl_manifest_path) and course_hitl is not None,
+        "cohort_hitl_manifest": bool(cohort_hitl_manifest_path)
+        and cohort_hitl is not None,
+        "course_hitl_manifest": bool(course_hitl_manifest_path)
+        and course_hitl is not None,
     }
     return df, availability
 

--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/ui/sma/enriched_schema_contract.py
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/ui/sma/enriched_schema_contract.py
@@ -128,7 +128,9 @@ def load_json_object_from_text(raw: str) -> dict[str, Any]:
     return data
 
 
-_WHITESPACE_VISIBLE_MARK = "\u00b7"  # middle dot; renders leading/trailing spaces visibly
+_WHITESPACE_VISIBLE_MARK = (
+    "\u00b7"  # middle dot; renders leading/trailing spaces visibly
+)
 
 
 def visualize_value_whitespace(value: Any) -> tuple[str, bool]:
@@ -153,5 +155,9 @@ def visualize_value_whitespace(value: Any) -> tuple[str, bool]:
         return _WHITESPACE_VISIBLE_MARK * len(s), True
     lead = len(s) - len(s.lstrip())
     trail = len(s) - len(s.rstrip())
-    visible = (_WHITESPACE_VISIBLE_MARK * lead) + stripped + (_WHITESPACE_VISIBLE_MARK * trail)
+    visible = (
+        (_WHITESPACE_VISIBLE_MARK * lead)
+        + stripped
+        + (_WHITESPACE_VISIBLE_MARK * trail)
+    )
     return visible, True

--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/ui/sma/enriched_schema_contract.py
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/ui/sma/enriched_schema_contract.py
@@ -98,7 +98,11 @@ def extract_column_panel_fields(
     sample_values = _as_str_list(row.get("sample_values"))
     chips: list[str]
     chip_mode: str
-    if isinstance(unique_values, list) and len(unique_values) <= 20:
+    # Profiling (contract_builder.UNIQUE_VALUES_MAX_CARDINALITY) only populates `unique_values`
+    # for low-cardinality columns (<=50 distinct) in the first place — trust that cutoff here
+    # rather than re-capping more strictly and silently falling back to "top 5 by frequency"
+    # for a column that's genuinely enumerable (e.g. 21-50 grade/status codes).
+    if isinstance(unique_values, list) and len(unique_values) > 0:
         chips = [str(x) for x in unique_values if x is not None]
         chip_mode = "unique"
     else:
@@ -122,3 +126,32 @@ def load_json_object_from_text(raw: str) -> dict[str, Any]:
     if not isinstance(data, dict):
         raise TypeError("Expected JSON object")
     return data
+
+
+_WHITESPACE_VISIBLE_MARK = "\u00b7"  # middle dot; renders leading/trailing spaces visibly
+
+
+def visualize_value_whitespace(value: Any) -> tuple[str, bool]:
+    """
+    Display-only rendering of a raw column value with leading/trailing whitespace made visible
+    (e.g. ``"A       "`` -> ``"A·······"``) instead of silently truncated or indistinguishable
+    from the trimmed value.
+
+    Common cause: source systems that export fixed-width/CHAR columns (e.g. some SIS/mainframe
+    extracts) pad string values to a fixed length. That padding is real source data — this
+    function does not strip or otherwise alter it, only makes it visible in review UIs so a
+    reviewer isn't confused by "duplicate-looking" chips like ``"A"`` and ``"A       "``.
+
+    Returns ``(display_string, had_padding)``.
+    """
+    s = "" if value is None else str(value)
+    stripped = s.strip()
+    if s == stripped:
+        return s, False
+    if not stripped:
+        # Whitespace-only value (should already be nulled by upstream cleaning, but be defensive).
+        return _WHITESPACE_VISIBLE_MARK * len(s), True
+    lead = len(s) - len(s.lstrip())
+    trail = len(s) - len(s.rstrip())
+    visible = (_WHITESPACE_VISIBLE_MARK * lead) + stripped + (_WHITESPACE_VISIBLE_MARK * trail)
+    return visible, True

--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/ui/sma/manifest_review_ui.py
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/ui/sma/manifest_review_ui.py
@@ -32,6 +32,7 @@ from hitl_reviewer.ui.sma.enriched_schema_contract import (
     enriched_schema_contract_path_from_manifest,
     extract_column_panel_fields,
     load_json_object_from_text,
+    visualize_value_whitespace,
 )
 from hitl_reviewer.platform.unity_volume_files import read_unity_file_text
 
@@ -381,14 +382,33 @@ def render_sma_source_column_panel(
         chips = panel.get("chip_values") or []
         mode = panel.get("chip_mode", "sample")
         if chips:
-            esc = "".join(
-                f'<span class="hitl-chip">{html.escape(str(v))[:200]}</span>'
-                for v in chips[:80]
-            )
+            any_padded = False
+            spans: list[str] = []
+            for v in chips[:80]:
+                display, had_padding = visualize_value_whitespace(v)
+                any_padded = any_padded or had_padding
+                cls = "hitl-chip hitl-chip-padded" if had_padding else "hitl-chip"
+                title = (
+                    "Source value has leading/trailing whitespace (e.g. a fixed-width "
+                    "source column) — shown here as \u00b7 so it isn't confused with the "
+                    "trimmed value."
+                    if had_padding
+                    else ""
+                )
+                spans.append(
+                    f'<span class="{cls}" title="{html.escape(title)}">'
+                    f"{html.escape(display)[:200]}</span>"
+                )
+            esc = "".join(spans)
             st.markdown(
                 f'<div class="hitl-chip-row" title="{html.escape(str(mode))}">{esc}</div>',
                 unsafe_allow_html=True,
             )
+            if any_padded:
+                st.caption(
+                    "\u00b7 marks leading/trailing whitespace present in the raw source "
+                    "value (not stripped — shown as-is)."
+                )
         else:
             st.caption("—")
 

--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/pages/3_Manifest_Explorer.py
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/pages/3_Manifest_Explorer.py
@@ -262,12 +262,15 @@ display_cols = core_cols + [c for c in extra_pick if c not in core_cols]
 
 column_config = {
     "sample_values": st.column_config.TextColumn(
-        "values (preview)",
+        "values",
+        width="large",
         help=(
-            "Unique values when the column has <=50 distinct values (per the enriched schema "
-            "contract), else the 5 most frequent values. Truncated to 12 here — see the detail "
-            "panel below for the full list. Leading/trailing whitespace in a value (e.g. a "
-            "padded fixed-width source column) is shown as \u00b7 rather than stripped."
+            "\"unique (N)\": the complete set of N distinct values — shown whenever the "
+            "enriched schema contract judged this column low-cardinality (<=50 distinct). "
+            "\"sample, top 5\": only shown when the column exceeds that cardinality and the "
+            "contract never computed a full distinct list — the 5 most frequent values, not "
+            "exhaustive. Leading/trailing whitespace in a value (e.g. a padded fixed-width "
+            "source column) is shown as \u00b7 rather than stripped."
         ),
     ),
 }

--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/pages/3_Manifest_Explorer.py
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/pages/3_Manifest_Explorer.py
@@ -32,6 +32,7 @@ from hitl_reviewer.ui.manifest_explorer import (
     load_json_object_or_none,
     resolve_explorer_paths,
 )
+from hitl_reviewer.ui.sma.enriched_schema_contract import visualize_value_whitespace
 from hitl_reviewer.utils.institution_naming import format_institution_display_name
 
 st.set_page_config(page_title="Manifest explorer", layout="wide")
@@ -226,23 +227,58 @@ if search.strip():
 
 st.caption(f"**{len(filtered)} of {len(df)}** field mappings shown.")
 
-display_cols = [
+# Core columns fit on-screen without horizontal scroll; `join` / `row_selection` / values
+# preview are intentionally left out by default since they're already shown in full in the
+# detail panel below when you select a row — add them back here only if you want them visible
+# across every row at once.
+_CORE_COLS = [
     "entity_type",
     "target_field",
     "source_table",
     "source_column",
-    "join",
-    "row_selection",
     "confidence",
     "review_status",
     "flagged_for_hitl",
+    "has_padded_values",
+]
+_OPTIONAL_COLS = [
+    "join",
+    "row_selection",
     "hitl_failure_mode",
     "dtype",
     "null_percentage",
     "unique_count",
     "sample_values",
 ]
-display_cols = [c for c in display_cols if c in filtered.columns]
+core_cols = [c for c in _CORE_COLS if c in filtered.columns]
+optional_cols = [c for c in _OPTIONAL_COLS if c in filtered.columns]
+extra_pick = st.multiselect(
+    "+ more columns",
+    options=optional_cols,
+    default=[],
+    help="Add columns to the table below. Full detail (join, row selection, all values) is "
+    "always available in the detail panel after selecting a row, regardless of this picker.",
+)
+display_cols = core_cols + [c for c in extra_pick if c not in core_cols]
+
+column_config = {
+    "sample_values": st.column_config.TextColumn(
+        "values (preview)",
+        help=(
+            "Unique values when the column has <=50 distinct values (per the enriched schema "
+            "contract), else the 5 most frequent values. Truncated to 12 here — see the detail "
+            "panel below for the full list."
+        ),
+    ),
+    "has_padded_values": st.column_config.CheckboxColumn(
+        "padded?",
+        help=(
+            "Source column has values with leading/trailing whitespace (e.g. a fixed-width "
+            "CHAR export) — visible as \u00b7 in values (preview) / the detail panel below. "
+            "This reflects the raw source data, not a display bug."
+        ),
+    ),
+}
 
 event = st.dataframe(
     filtered[display_cols],
@@ -252,6 +288,7 @@ event = st.dataframe(
     on_select="rerun",
     selection_mode="single-row",
     key="manifest_explorer_table",
+    column_config=column_config,
 )
 
 st.download_button(
@@ -305,12 +342,32 @@ if sel_rows:
         label = "Unique values" if mode == "unique" else "Sample values"
         st.caption(label)
         if chips:
-            esc = "".join(
-                f'<span class="hitl-chip">{html.escape(v)[:200]}</span>' for v in chips
-            )
+            any_padded = False
+            spans: list[str] = []
+            for v in chips:
+                display, had_padding = visualize_value_whitespace(v)
+                any_padded = any_padded or had_padding
+                cls = "hitl-chip hitl-chip-padded" if had_padding else "hitl-chip"
+                title = (
+                    "Source value has leading/trailing whitespace (e.g. a fixed-width "
+                    "source column) — shown here as \u00b7 so it isn't confused with the "
+                    "trimmed value."
+                    if had_padding
+                    else ""
+                )
+                spans.append(
+                    f'<span class="{cls}" title="{html.escape(title)}">'
+                    f"{html.escape(display)[:200]}</span>"
+                )
             st.markdown(
-                f'<div class="hitl-chip-row">{esc}</div>', unsafe_allow_html=True
+                f'<div class="hitl-chip-row">{"".join(spans)}</div>',
+                unsafe_allow_html=True,
             )
+            if any_padded:
+                st.caption(
+                    "\u00b7 marks leading/trailing whitespace present in the raw source "
+                    "value (not stripped — shown as-is)."
+                )
         else:
             st.caption("—")
 

--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/pages/3_Manifest_Explorer.py
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/pages/3_Manifest_Explorer.py
@@ -227,23 +227,19 @@ if search.strip():
 
 st.caption(f"**{len(filtered)} of {len(df)}** field mappings shown.")
 
-# Core columns fit on-screen without horizontal scroll; `join` / `row_selection` / values
-# preview are intentionally left out by default since they're already shown in full in the
-# detail panel below when you select a row — add them back here only if you want them visible
-# across every row at once.
 _CORE_COLS = [
     "entity_type",
     "target_field",
     "source_table",
     "source_column",
+    "sample_values",
+    "null_percentage",
     "confidence",
     "review_status",
-    "null_percentage",
-    "sample_values",
-]
-_OPTIONAL_COLS = [
     "join",
     "row_selection",
+]
+_OPTIONAL_COLS = [
     "flagged_for_hitl",
     "hitl_failure_mode",
     "dtype",
@@ -255,8 +251,8 @@ extra_pick = st.multiselect(
     "+ more columns",
     options=optional_cols,
     default=[],
-    help="Add columns to the table below. Full detail (join, row selection, all values) is "
-    "always available in the detail panel after selecting a row, regardless of this picker.",
+    help="Add columns to the table below. Full detail is always available in the detail "
+    "panel after selecting a row, regardless of this picker.",
 )
 display_cols = core_cols + [c for c in extra_pick if c not in core_cols]
 

--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/pages/3_Manifest_Explorer.py
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/pages/3_Manifest_Explorer.py
@@ -15,7 +15,9 @@ import pandas as pd
 import streamlit as st
 
 from hitl_reviewer.platform.databricks_uc_sql import load_onboard_runs_hitl_complete
-from hitl_reviewer.platform.volume_path_utils import institution_id_from_silver_volume_path
+from hitl_reviewer.platform.volume_path_utils import (
+    institution_id_from_silver_volume_path,
+)
 from hitl_reviewer.ui._shared import inject_hitl_css, render_institution_line
 from hitl_reviewer.ui.hitl_streamlit import (
     default_catalog,
@@ -159,8 +161,16 @@ if st.button("Reload manifest/contract from volume"):
 
 envelope = _cached_json_object(paths["manifest_map"])
 contract = _cached_json_object(paths["enriched_schema_contract"])
-cohort_hitl = _cached_json_object(paths["cohort_hitl_manifest"]) if paths["cohort_hitl_manifest"] else None
-course_hitl = _cached_json_object(paths["course_hitl_manifest"]) if paths["course_hitl_manifest"] else None
+cohort_hitl = (
+    _cached_json_object(paths["cohort_hitl_manifest"])
+    if paths["cohort_hitl_manifest"]
+    else None
+)
+course_hitl = (
+    _cached_json_object(paths["course_hitl_manifest"])
+    if paths["course_hitl_manifest"]
+    else None
+)
 
 df = flatten_manifest_envelope(envelope)
 df = attach_hitl_status(df, cohort_hitl=cohort_hitl, course_hitl=course_hitl)
@@ -169,8 +179,10 @@ df = attach_column_stats(df, contract)
 availability = {
     "manifest_map": envelope is not None,
     "enriched_schema_contract": contract is not None,
-    "cohort_hitl_manifest": bool(paths["cohort_hitl_manifest"]) and cohort_hitl is not None,
-    "course_hitl_manifest": bool(paths["course_hitl_manifest"]) and course_hitl is not None,
+    "cohort_hitl_manifest": bool(paths["cohort_hitl_manifest"])
+    and cohort_hitl is not None,
+    "course_hitl_manifest": bool(paths["course_hitl_manifest"])
+    and course_hitl is not None,
 }
 
 missing = []
@@ -180,9 +192,13 @@ if not availability["enriched_schema_contract"]:
     missing.append("enriched_schema_contract.json (column stats will be blank)")
 if source != "Active":
     if not availability["cohort_hitl_manifest"]:
-        missing.append("cohort_hitl_manifest.json (HITL status will be blank for cohort fields)")
+        missing.append(
+            "cohort_hitl_manifest.json (HITL status will be blank for cohort fields)"
+        )
     if not availability["course_hitl_manifest"]:
-        missing.append("course_hitl_manifest.json (HITL status will be blank for course fields)")
+        missing.append(
+            "course_hitl_manifest.json (HITL status will be blank for course fields)"
+        )
 if missing:
     st.warning("Could not read: " + "; ".join(missing))
 
@@ -200,7 +216,9 @@ with f_cols[0]:
         default=sorted(df["entity_type"].dropna().unique().tolist()),
     )
 with f_cols[1]:
-    status_options = sorted([s for s in df["review_status"].dropna().unique().tolist() if s])
+    status_options = sorted(
+        [s for s in df["review_status"].dropna().unique().tolist() if s]
+    )
     status_pick = st.multiselect("Review status", options=status_options, default=[])
 with f_cols[2]:
     flagged_only = st.checkbox("Flagged for HITL only", value=False)
@@ -261,9 +279,9 @@ column_config = {
         "values",
         width="large",
         help=(
-            "\"unique (N)\": the complete set of N distinct values — shown whenever the "
+            '"unique (N)": the complete set of N distinct values — shown whenever the '
             "enriched schema contract judged this column low-cardinality (<=50 distinct). "
-            "\"sample, top 5\": only shown when the column exceeds that cardinality and the "
+            '"sample, top 5": only shown when the column exceeds that cardinality and the '
             "contract never computed a full distinct list — the 5 most frequent values, not "
             "exhaustive. Leading/trailing whitespace in a value (e.g. a padded fixed-width "
             "source column) is shown as \u00b7 rather than stripped."
@@ -372,4 +390,6 @@ if sel_rows:
         st.markdown("**Reviewer notes**")
         st.caption(row.get("reviewer_notes"))
 else:
-    st.caption("Select a row above to see full sourcing detail and source-column values.")
+    st.caption(
+        "Select a row above to see full sourcing detail and source-column values."
+    )

--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/pages/3_Manifest_Explorer.py
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/pages/3_Manifest_Explorer.py
@@ -1,0 +1,327 @@
+"""
+Manifest Explorer: one consolidated table joining the Step 2a field mapping manifest
+(``manifest_map.json``), per-column stats from the enriched schema contract, and HITL
+review status — so reviewing a manifest doesn't require opening several separate JSON
+files (see ``pages/2_Maps_and_Outputs.py`` for the raw per-file browser this complements).
+
+Catalog comes from ``GENAI_HITL_CATALOG`` / default, same as **Maps & outputs**.
+"""
+
+from __future__ import annotations
+
+import html
+
+import pandas as pd
+import streamlit as st
+
+from hitl_reviewer.platform.databricks_uc_sql import load_onboard_runs_hitl_complete
+from hitl_reviewer.platform.volume_path_utils import institution_id_from_silver_volume_path
+from hitl_reviewer.ui._shared import inject_hitl_css, render_institution_line
+from hitl_reviewer.ui.hitl_streamlit import (
+    default_catalog,
+    init_reviewer_in_session,
+    init_sidebar_form_state,
+    render_warehouse_sidebar,
+    validate_catalog,
+)
+from hitl_reviewer.ui.manifest_explorer import (
+    attach_column_stats,
+    attach_hitl_status,
+    flatten_manifest_envelope,
+    full_column_sample_values,
+    load_json_object_or_none,
+    resolve_explorer_paths,
+)
+from hitl_reviewer.utils.institution_naming import format_institution_display_name
+
+st.set_page_config(page_title="Manifest explorer", layout="wide")
+init_reviewer_in_session()
+init_sidebar_form_state()
+inject_hitl_css()
+
+st.title("Manifest explorer")
+st.caption(
+    "One table for the Step 2a field mapping manifest: source table/column, join + row "
+    "selection, confidence, HITL status, and source-column stats (null rate, unique count, "
+    "sample values) from the enriched schema contract — joined by target field so you don't "
+    "have to open ``manifest_map.json``, ``enriched_schema_contract.json``, and the HITL "
+    "manifests separately."
+)
+
+warehouse_ok = render_warehouse_sidebar(
+    page_heading="Manifest explorer",
+    page_caption="Warehouse must be configured (``DATABRICKS_WAREHOUSE_ID``). Catalog is not edited here.",
+)
+if not warehouse_ok:
+    st.stop()
+
+try:
+    catalog = validate_catalog(default_catalog())
+except ValueError as e:
+    st.error(str(e))
+    st.stop()
+
+st.caption(f"**Queries use catalog:** `{catalog}` (`GENAI_HITL_CATALOG` / default).")
+
+if st.button("Refresh run list from Unity Catalog"):
+    for k in ("manifest_explorer_runs_df", "manifest_explorer_runs_err"):
+        st.session_state.pop(k, None)
+    st.rerun()
+
+if "manifest_explorer_runs_df" not in st.session_state:
+    try:
+        raw = load_onboard_runs_hitl_complete(catalog)
+        if raw.empty:
+            st.session_state["manifest_explorer_runs_df"] = raw
+        else:
+            ap = raw["sample_artifact_path"].astype(str)
+            onboard_mask = ap.str.contains("/runs/onboard/", case=False, na=False)
+            work = raw.loc[onboard_mask].copy()
+
+            def _resolve_institution(row: pd.Series) -> str:
+                explicit = str(row.get("institution_id") or "").strip()
+                if explicit:
+                    return explicit
+                p = str(row.get("sample_artifact_path") or "").strip()
+                return institution_id_from_silver_volume_path(p) or ""
+
+            work["_institution_id"] = work.apply(_resolve_institution, axis=1)
+            work = work[work["_institution_id"].astype(str).str.len() > 0]
+            st.session_state["manifest_explorer_runs_df"] = work
+        st.session_state["manifest_explorer_runs_err"] = None
+    except Exception as e:  # noqa: BLE001
+        st.session_state["manifest_explorer_runs_df"] = pd.DataFrame()
+        st.session_state["manifest_explorer_runs_err"] = str(e)
+
+if st.session_state.get("manifest_explorer_runs_err"):
+    st.error(st.session_state["manifest_explorer_runs_err"])
+    st.stop()
+
+runs_df: pd.DataFrame = st.session_state["manifest_explorer_runs_df"]
+if runs_df.empty:
+    st.warning(
+        "No onboard runs with HITL complete (and resolvable institution) found. "
+        "Try **Refresh run list** after more reviews finish, or confirm catalog and warehouse access."
+    )
+    st.stop()
+
+institutions = sorted(runs_df["_institution_id"].astype(str).unique().tolist())
+inst_pick = st.selectbox("Institution", options=institutions, index=0)
+render_institution_line(inst_raw=inst_pick, format_fn=format_institution_display_name)
+
+source = st.radio(
+    "Manifest source",
+    options=["Onboard run (HITL complete)", "Active"],
+    horizontal=True,
+)
+
+run_pick: str | None = None
+if source == "Active":
+    paths = resolve_explorer_paths(inst_pick, catalog, onboard_run_id=None)
+else:
+    sub = runs_df.loc[runs_df["_institution_id"].astype(str) == inst_pick].copy()
+    sub = sub.sort_values("last_reviewed_at", ascending=False, na_position="last")
+    run_ids = (
+        sub.drop_duplicates(subset=["onboard_run_id"], keep="first")["onboard_run_id"]
+        .astype(str)
+        .tolist()
+    )
+    if not run_ids:
+        st.warning("No HITL-complete onboard runs found for this institution.")
+        st.stop()
+    run_pick = st.selectbox("Onboard run", options=run_ids, index=0)
+    paths = resolve_explorer_paths(inst_pick, catalog, onboard_run_id=str(run_pick))
+
+st.divider()
+st.caption(f"**Manifest map:** `{paths['manifest_map']}`")
+
+
+def _cached_json_object(path: str) -> dict | None:
+    """Session-cached read; keyed the same way as the per-item SMA HITL panel's contract cache
+    (``esc-json-{path}``) so switching between this page and HITL Review reuses one fetch."""
+    if not path:
+        return None
+    ck = f"esc-json-{path}"
+    if ck not in st.session_state:
+        st.session_state[ck] = {"ok": False, "obj": None}
+        obj = load_json_object_or_none(path)
+        st.session_state[ck] = {"ok": obj is not None, "obj": obj}
+    cached = st.session_state[ck]
+    return cached.get("obj") if cached.get("ok") else None
+
+
+if st.button("Reload manifest/contract from volume"):
+    for key in list(st.session_state.keys()):
+        if isinstance(key, str) and key.startswith("esc-json-"):
+            del st.session_state[key]
+    st.rerun()
+
+envelope = _cached_json_object(paths["manifest_map"])
+contract = _cached_json_object(paths["enriched_schema_contract"])
+cohort_hitl = _cached_json_object(paths["cohort_hitl_manifest"]) if paths["cohort_hitl_manifest"] else None
+course_hitl = _cached_json_object(paths["course_hitl_manifest"]) if paths["course_hitl_manifest"] else None
+
+df = flatten_manifest_envelope(envelope)
+df = attach_hitl_status(df, cohort_hitl=cohort_hitl, course_hitl=course_hitl)
+df = attach_column_stats(df, contract)
+
+availability = {
+    "manifest_map": envelope is not None,
+    "enriched_schema_contract": contract is not None,
+    "cohort_hitl_manifest": bool(paths["cohort_hitl_manifest"]) and cohort_hitl is not None,
+    "course_hitl_manifest": bool(paths["course_hitl_manifest"]) and course_hitl is not None,
+}
+
+missing = []
+if not availability["manifest_map"]:
+    missing.append("manifest_map.json")
+if not availability["enriched_schema_contract"]:
+    missing.append("enriched_schema_contract.json (column stats will be blank)")
+if source != "Active":
+    if not availability["cohort_hitl_manifest"]:
+        missing.append("cohort_hitl_manifest.json (HITL status will be blank for cohort fields)")
+    if not availability["course_hitl_manifest"]:
+        missing.append("course_hitl_manifest.json (HITL status will be blank for course fields)")
+if missing:
+    st.warning("Could not read: " + "; ".join(missing))
+
+if df.empty:
+    st.info("No field mappings found at this path.")
+    st.stop()
+
+st.divider()
+st.subheader("Filters")
+f_cols = st.columns([1, 1, 1, 2])
+with f_cols[0]:
+    entity_pick = st.multiselect(
+        "Entity type",
+        options=sorted(df["entity_type"].dropna().unique().tolist()),
+        default=sorted(df["entity_type"].dropna().unique().tolist()),
+    )
+with f_cols[1]:
+    status_options = sorted([s for s in df["review_status"].dropna().unique().tolist() if s])
+    status_pick = st.multiselect("Review status", options=status_options, default=[])
+with f_cols[2]:
+    flagged_only = st.checkbox("Flagged for HITL only", value=False)
+with f_cols[3]:
+    search = st.text_input(
+        "Search (target field / source table / source column)", value=""
+    )
+
+filtered = df.copy()
+if entity_pick:
+    filtered = filtered[filtered["entity_type"].isin(entity_pick)]
+if status_pick:
+    filtered = filtered[filtered["review_status"].isin(status_pick)]
+if flagged_only:
+    filtered = filtered[filtered["flagged_for_hitl"] == True]  # noqa: E712
+if search.strip():
+    s = search.strip().lower()
+    mask = (
+        filtered["target_field"].astype(str).str.lower().str.contains(s, na=False)
+        | filtered["source_table"].astype(str).str.lower().str.contains(s, na=False)
+        | filtered["source_column"].astype(str).str.lower().str.contains(s, na=False)
+    )
+    filtered = filtered[mask]
+
+st.caption(f"**{len(filtered)} of {len(df)}** field mappings shown.")
+
+display_cols = [
+    "entity_type",
+    "target_field",
+    "source_table",
+    "source_column",
+    "join",
+    "row_selection",
+    "confidence",
+    "review_status",
+    "flagged_for_hitl",
+    "hitl_failure_mode",
+    "dtype",
+    "null_percentage",
+    "unique_count",
+    "sample_values",
+]
+display_cols = [c for c in display_cols if c in filtered.columns]
+
+event = st.dataframe(
+    filtered[display_cols],
+    use_container_width=True,
+    hide_index=True,
+    height=460,
+    on_select="rerun",
+    selection_mode="single-row",
+    key="manifest_explorer_table",
+)
+
+st.download_button(
+    "Download filtered table as CSV",
+    data=filtered[display_cols].to_csv(index=False).encode("utf-8"),
+    file_name=f"manifest_explorer_{inst_pick}_{run_pick or 'active'}.csv",
+    mime="text/csv",
+)
+
+sel_rows = (event.get("selection") or {}).get("rows") or []
+if sel_rows:
+    ridx = filtered.index[sel_rows[0]]
+    row = filtered.loc[ridx]
+    st.divider()
+    st.subheader(f"Detail — `{row.get('target_field')}` ({row.get('entity_type')})")
+
+    d_cols = st.columns(2)
+    with d_cols[0]:
+        st.markdown("**Sourcing**")
+        st.markdown(
+            f"- Source: `{row.get('source_table')}` . `{row.get('source_column')}`\n"
+            f"- Confidence: `{row.get('confidence')}`\n"
+            f"- Review status: `{row.get('review_status') or '—'}`\n"
+            f"- Flagged for HITL: `{row.get('flagged_for_hitl')}`"
+            + (
+                f" (`{row.get('hitl_failure_mode')}`)"
+                if row.get("flagged_for_hitl")
+                else ""
+            )
+        )
+        if row.get("hitl_question"):
+            st.caption(f"HITL question: {row.get('hitl_question')}")
+        if row.get("_join_raw"):
+            st.markdown("Join (raw)")
+            st.json(row.get("_join_raw"))
+        if row.get("_row_selection_raw"):
+            st.markdown("Row selection (raw)")
+            st.json(row.get("_row_selection_raw"))
+
+    with d_cols[1]:
+        st.markdown("**Source column detail**")
+        chips, mode = full_column_sample_values(
+            contract,
+            source_table=row.get("source_table"),
+            source_column=row.get("source_column"),
+        )
+        st.caption(
+            f"dtype `{row.get('dtype') or '—'}` · null rate `{row.get('null_percentage')}"
+            f"%` ({row.get('null_count')} rows) · unique `{row.get('unique_count')}`"
+        )
+        label = "Unique values" if mode == "unique" else "Sample values"
+        st.caption(label)
+        if chips:
+            esc = "".join(
+                f'<span class="hitl-chip">{html.escape(v)[:200]}</span>' for v in chips
+            )
+            st.markdown(
+                f'<div class="hitl-chip-row">{esc}</div>', unsafe_allow_html=True
+            )
+        else:
+            st.caption("—")
+
+    if row.get("rationale"):
+        st.markdown("**Model rationale**")
+        st.caption(row.get("rationale"))
+    if row.get("validation_notes"):
+        st.markdown("**Predicted validation notes**")
+        st.caption(row.get("validation_notes"))
+    if row.get("reviewer_notes"):
+        st.markdown("**Reviewer notes**")
+        st.caption(row.get("reviewer_notes"))
+else:
+    st.caption("Select a row above to see full sourcing detail and source-column values.")

--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/pages/3_Manifest_Explorer.py
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/pages/3_Manifest_Explorer.py
@@ -238,17 +238,16 @@ _CORE_COLS = [
     "source_column",
     "confidence",
     "review_status",
-    "flagged_for_hitl",
-    "has_padded_values",
+    "null_percentage",
+    "sample_values",
 ]
 _OPTIONAL_COLS = [
     "join",
     "row_selection",
+    "flagged_for_hitl",
     "hitl_failure_mode",
     "dtype",
-    "null_percentage",
     "unique_count",
-    "sample_values",
 ]
 core_cols = [c for c in _CORE_COLS if c in filtered.columns]
 optional_cols = [c for c in _OPTIONAL_COLS if c in filtered.columns]
@@ -267,15 +266,8 @@ column_config = {
         help=(
             "Unique values when the column has <=50 distinct values (per the enriched schema "
             "contract), else the 5 most frequent values. Truncated to 12 here — see the detail "
-            "panel below for the full list."
-        ),
-    ),
-    "has_padded_values": st.column_config.CheckboxColumn(
-        "padded?",
-        help=(
-            "Source column has values with leading/trailing whitespace (e.g. a fixed-width "
-            "CHAR export) — visible as \u00b7 in values (preview) / the detail panel below. "
-            "This reflects the raw source data, not a display bug."
+            "panel below for the full list. Leading/trailing whitespace in a value (e.g. a "
+            "padded fixed-width source column) is shown as \u00b7 rather than stripped."
         ),
     ),
 }


### PR DESCRIPTION
## Summary
- Adds a new **Manifest Explorer** page that consolidates the Step 2a field mapping manifest (`manifest_map.json`), per-column stats from the enriched schema contract, and HITL review status into a single filterable table — so reviewing a manifest no longer requires opening several separate JSON files.
- Table shows source table/column, join + row selection, confidence, HITL status, null rate, and a values preview per row, with a "+ more columns" picker and a per-row detail panel for full field-level detail.
- Values preview shows the complete unique-value list (bounded by the enriched schema contract's own <=50 cardinality cap) when available, clearly labeled `unique (N):` vs. `sample, top 5:` so it's unambiguous whether you're looking at an exhaustive list or a frequency sample.
- Leading/trailing whitespace in source values (e.g. padded fixed-width source columns) is rendered visibly (as `·`) instead of being silently indistinguishable from the trimmed value — display-only, underlying data is untouched.

## Asana
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1213763082591363?focus=true

## Test plan
- [x] Verified whitespace visualization against a real padded `grade` column example (12 fixed-width codes)
- [x] Verified full unique-value list renders without truncation, and correctly falls back to `sample, top 5` for high-cardinality columns
- [x] Smoke-tested the Streamlit page locally (clean load, HTTP 200)
- [x] Deployed to the `dev` Databricks app and manually verified in-browser; `staging` untouched
- [ ] Reviewer sanity-check on `dev`: https://edvise-genai-hitl-dev-4437281602191762.gcp.databricksapps.com

Made with [Cursor](https://cursor.com)