### PR TITLE
fix(genai): auto-sort non-chronological season_map in term HITL UI

### DIFF
--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/persistence/silver_hitl_paths.py
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/persistence/silver_hitl_paths.py
@@ -154,8 +154,12 @@ def sort_season_map_dataframe_chronologically(df: pd.DataFrame) -> pd.DataFrame:
     if df.empty:
         return df.reset_index(drop=True)
     unknown_rank = max(_CALENDAR_CHRONOLOGY_RANK.values()) + 1
-    rank_col = df["canonical"].astype(str).str.strip().str.upper().map(
-        lambda c: _CALENDAR_CHRONOLOGY_RANK.get(c, unknown_rank)
+    rank_col = (
+        df["canonical"]
+        .astype(str)
+        .str.strip()
+        .str.upper()
+        .map(lambda c: _CALENDAR_CHRONOLOGY_RANK.get(c, unknown_rank))
     )
     sorted_df = df.assign(_chrono_rank=rank_col).sort_values(
         "_chrono_rank", kind="stable"

--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/persistence/silver_hitl_paths.py
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/persistence/silver_hitl_paths.py
@@ -104,6 +104,64 @@ def set_item_reviewer_note(
 
 _CANONICAL_SEASONS = frozenset({"FALL", "SPRING", "SUMMER", "WINTER"})
 
+# Mirrors edvise.genai.mapping.identity_agent.term_normalization.schemas.CALENDAR_CHRONOLOGY_RANK
+# (kept local/duplicated — this app has no runtime dependency on the ``edvise`` pipeline package).
+_CALENDAR_CHRONOLOGY_RANK: dict[str, int] = {
+    "SPRING": 1,
+    "SUMMER": 2,
+    "FALL": 3,
+    "WINTER": 4,
+}
+
+
+def season_map_rows_chronology_error(rows: list[dict[str, str]]) -> str | None:
+    """
+    Return an error message when ``rows`` canonicals are not calendar-chronological.
+
+    Same rule as the pipeline's ``season_map_chronology_error``: list position's canonical
+    calendar rank (SPRING → SUMMER → FALL → WINTER) must be non-decreasing top-to-bottom.
+    Duplicate canonicals are allowed. Kept in sync with
+    :func:`edvise.genai.mapping.identity_agent.term_normalization.schemas.season_map_chronology_error`
+    so the UI can flag the same violation before it reaches pipeline resolve.
+    """
+    prev_rank: int | None = None
+    prev_pos = 0
+    prev_canon = ""
+    for pos, row in enumerate(rows, start=1):
+        canonical = str(row.get("canonical", "")).strip().upper()
+        rank = _CALENDAR_CHRONOLOGY_RANK.get(canonical)
+        if rank is None:
+            continue
+        if prev_rank is not None and rank < prev_rank:
+            return (
+                "Season map must be calendar-chronological "
+                "(SPRING → SUMMER → FALL → WINTER): "
+                f"{prev_canon} (row {prev_pos}) precedes {canonical} (row {pos})."
+            )
+        prev_rank, prev_pos, prev_canon = rank, pos, canonical
+    return None
+
+
+def sort_season_map_dataframe_chronologically(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Reorder ``season_map`` rows into SPRING → SUMMER → FALL → WINTER calendar order.
+
+    Stable sort: rows sharing a canonical (e.g. two SUMMER raw tokens) keep their existing
+    relative order. Rows with a blank/unrecognized canonical (mid-edit, new blank row) sort
+    to the bottom rather than raising, since :func:`season_map_rows_chronology_error` /
+    ``validated_season_map_replace_from_dataframe`` still catch those at save time.
+    """
+    if df.empty:
+        return df.reset_index(drop=True)
+    unknown_rank = max(_CALENDAR_CHRONOLOGY_RANK.values()) + 1
+    rank_col = df["canonical"].astype(str).str.strip().str.upper().map(
+        lambda c: _CALENDAR_CHRONOLOGY_RANK.get(c, unknown_rank)
+    )
+    sorted_df = df.assign(_chrono_rank=rank_col).sort_values(
+        "_chrono_rank", kind="stable"
+    )
+    return sorted_df.drop(columns="_chrono_rank").reset_index(drop=True)
+
 
 def validated_season_map_replace_from_dataframe(
     df: object,
@@ -138,6 +196,9 @@ def validated_season_map_replace_from_dataframe(
                 f"{sorted(_CANONICAL_SEASONS)}.",
             )
         rows_out.append({"raw": raw, "canonical": canonical})
+    chrono_err = season_map_rows_chronology_error(rows_out)
+    if chrono_err:
+        return None, chrono_err
     return rows_out, None
 
 

--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/ui/ia/term_review_ui.py
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/hitl_reviewer/ui/ia/term_review_ui.py
@@ -33,8 +33,10 @@ from hitl_reviewer.persistence.hitl_json_batch_commit import (
 )
 from hitl_reviewer.persistence.silver_hitl_paths import (
     ia_term_season_map_session_key,
+    season_map_rows_chronology_error,
     set_item_choice,
     set_item_reviewer_note,
+    sort_season_map_dataframe_chronologically,
 )
 from hitl_reviewer.ui.ia.term_season_map_guess import build_season_map_seed_dataframe
 from hitl_reviewer.platform.unity_volume_files import (
@@ -334,6 +336,22 @@ def render_ia_term_hitl_cards(
                 )
                 st.session_state[smr_key] = edited_smr.copy()
                 st.session_state.setdefault(smr_store_key, {})[loc] = edited_smr.copy()
+
+                chrono_err = season_map_rows_chronology_error(
+                    edited_smr.to_dict("records")
+                )
+                if chrono_err:
+                    sorted_df = sort_season_map_dataframe_chronologically(edited_smr)
+                    st.session_state[smr_key] = sorted_df
+                    st.session_state.setdefault(smr_store_key, {})[loc] = (
+                        sorted_df.copy()
+                    )
+                    st.toast(
+                        "↕️ Season map rows were out of calendar order — "
+                        "auto-sorted into SPRING → SUMMER → FALL → WINTER.",
+                        icon="↕️",
+                    )
+                    st.rerun()
 
         opened_k, all_nav_seen = mark_hitl_nav_visit(
             store_key=f"ia-term-nav-visit-{sk}",

--- a/tests/genai/mapping/test_hitl_term_season_map_persist.py
+++ b/tests/genai/mapping/test_hitl_term_season_map_persist.py
@@ -14,6 +14,8 @@ if str(_HITL_APP) not in sys.path:
 
 from hitl_reviewer.persistence.silver_hitl_paths import (
     merge_season_map_replace_into_selected_option,
+    season_map_rows_chronology_error,
+    sort_season_map_dataframe_chronologically,
     validated_season_map_replace_from_dataframe,
 )
 
@@ -23,6 +25,81 @@ def test_validated_season_map_replace_from_dataframe_ok() -> None:
     rows, err = validated_season_map_replace_from_dataframe(df)
     assert err is None
     assert rows == [{"raw": "01", "canonical": "SPRING"}]
+
+
+def test_validated_season_map_replace_from_dataframe_flags_out_of_order() -> None:
+    df = pd.DataFrame(
+        [
+            {"raw": "15", "canonical": "FALL"},
+            {"raw": "20", "canonical": "FALL"},
+            {"raw": "25", "canonical": "SPRING"},
+        ]
+    )
+    rows, err = validated_season_map_replace_from_dataframe(df)
+    assert rows is None
+    assert err is not None
+    assert "calendar-chronological" in err
+    assert "FALL (row 2) precedes SPRING (row 3)" in err
+
+
+def test_season_map_rows_chronology_error_ok_when_sorted() -> None:
+    rows = [
+        {"raw": "25", "canonical": "SPRING"},
+        {"raw": "35", "canonical": "SUMMER"},
+        {"raw": "15", "canonical": "FALL"},
+    ]
+    assert season_map_rows_chronology_error(rows) is None
+
+
+def test_season_map_rows_chronology_error_allows_duplicates() -> None:
+    rows = [
+        {"raw": "25", "canonical": "SPRING"},
+        {"raw": "30", "canonical": "SPRING"},
+        {"raw": "35", "canonical": "SUMMER"},
+    ]
+    assert season_map_rows_chronology_error(rows) is None
+
+
+def test_sort_season_map_dataframe_chronologically_reorders_and_is_stable() -> None:
+    df = pd.DataFrame(
+        [
+            {"raw": "15", "canonical": "FALL"},
+            {"raw": "20", "canonical": "FALL"},
+            {"raw": "25", "canonical": "SPRING"},
+            {"raw": "30", "canonical": "SPRING"},
+            {"raw": "35", "canonical": "SUMMER"},
+            {"raw": "40", "canonical": "SUMMER"},
+        ]
+    )
+    sorted_df = sort_season_map_dataframe_chronologically(df)
+    assert sorted_df["raw"].tolist() == ["25", "30", "35", "40", "15", "20"]
+    assert sorted_df["canonical"].tolist() == [
+        "SPRING",
+        "SPRING",
+        "SUMMER",
+        "SUMMER",
+        "FALL",
+        "FALL",
+    ]
+    assert season_map_rows_chronology_error(sorted_df.to_dict("records")) is None
+
+
+def test_sort_season_map_dataframe_chronologically_sends_blank_rows_last() -> None:
+    df = pd.DataFrame(
+        [
+            {"raw": "15", "canonical": "FALL"},
+            {"raw": "", "canonical": ""},
+            {"raw": "25", "canonical": "SPRING"},
+        ]
+    )
+    sorted_df = sort_season_map_dataframe_chronologically(df)
+    assert sorted_df["raw"].tolist() == ["25", "15", ""]
+
+
+def test_sort_season_map_dataframe_chronologically_empty_df() -> None:
+    df = pd.DataFrame(columns=["raw", "canonical"])
+    sorted_df = sort_season_map_dataframe_chronologically(df)
+    assert sorted_df.empty
 
 
 def test_merge_season_map_replace_into_selected_option() -> None:


### PR DESCRIPTION
## Summary
- The term HITL season_map editor (Streamlit) let reviewers save a `raw` → `canonical` table whose row order wasn't calendar-chronological, which surfaced later as a raw `ValueError: season_map must be calendar-chronological ...` during pipeline resolve.
- The editor now detects out-of-order rows (SPRING → SUMMER → FALL → WINTER) and auto-sorts them in place (stable sort, preserving relative order within a canonical) with an `st.toast` notification, since Streamlit's `data_editor` has no drag-to-reorder.
- `validated_season_map_replace_from_dataframe` (used on save) also rejects any residual out-of-order rows with the same message as a safety net, so a bad ordering can no longer reach pipeline resolve.

## Test plan
- [x] `uv run pytest tests/genai/mapping/test_hitl_term_season_map_persist.py -q` — 8 passed (new: chronology-error detection, sort helper reorder/stability/blank-rows-last/empty-df cases)
- [x] `uv run pytest tests/genai/mapping -q` — 492 passed
- [ ] Manual smoke test in the deployed HITL app: open a term item with a `season_map_replace` resolution, enter rows out of calendar order, confirm the toast fires and rows reorder automatically

Made with [Cursor](https://cursor.com)