### PR TITLE
fix: require opposite core terms for graduation label eligibility

### DIFF
--- a/src/edvise/targets/credits_earned.py
+++ b/src/edvise/targets/credits_earned.py
@@ -101,7 +101,10 @@ def compute_target(
     # Risk-label budget: legacy 4-term fall-centric -1. Eligibility endpoints (opposite
     # core term) are handled in :func:`shared.get_students_with_max_target_term_in_dataset`.
     intensity_num_terms_for_target = (
-        {k: max(v - 1.0, 1.0) for k, v in intensity_num_terms.items()}
+        {
+            intensity: max(num_terms - 1.0, 1.0)
+            for intensity, num_terms in intensity_num_terms.items()
+        }
         if num_terms_in_year == 4
         else intensity_num_terms
     )

--- a/src/edvise/targets/credits_earned.py
+++ b/src/edvise/targets/credits_earned.py
@@ -98,13 +98,13 @@ def compute_target(
     intensity_num_terms = utils.data_cleaning.convert_intensity_time_limits(
         "term", intensity_time_limits, num_terms_in_year=num_terms_in_year
     )
-    # Match :func:`graduation.compute_target`: four terms per year only, fall-to-spring
-    # paths span one fewer term than ``years * 4`` (see graduation for rationale).
-    if num_terms_in_year == 4:
-        intensity_num_terms = {
-            intensity: max(num_terms - 1.0, 1.0)
-            for intensity, num_terms in intensity_num_terms.items()
-        }
+    # Risk-label budget: legacy 4-term fall-centric -1. Eligibility endpoints (opposite
+    # core term) are handled in :func:`shared.get_students_with_max_target_term_in_dataset`.
+    intensity_num_terms_for_target = (
+        {k: max(v - 1.0, 1.0) for k, v in intensity_num_terms.items()}
+        if num_terms_in_year == 4
+        else intensity_num_terms
+    )
 
     # 6. Apply intensity-specific time limits and select at-risk student IDs
     # Check if student took more terms than allowed (e.g., full-time students get 12 terms, part-time get 16)
@@ -121,7 +121,7 @@ def compute_target(
                 | df_at[f"{tr_col}_tgt"].isna()
             )
         )
-        for intensity, num_terms in intensity_num_terms.items()
+        for intensity, num_terms in intensity_num_terms_for_target.items()
     ]
     target = np.logical_or.reduce(targets)
 
@@ -132,7 +132,7 @@ def compute_target(
         .astype({"target": "boolean"})
     )
 
-    # 7. Eligibility (see :func:`shared.get_students_with_max_target_term_in_dataset`):
+    # 7. Eligibility: pass raw term budgets; shared applies core-term endpoints.
     intensity_time_limits_for_eligibility = t.cast(
         utils.types.IntensityTimeLimitsType,
         {

--- a/src/edvise/targets/credits_earned.py
+++ b/src/edvise/targets/credits_earned.py
@@ -98,16 +98,13 @@ def compute_target(
     intensity_num_terms = utils.data_cleaning.convert_intensity_time_limits(
         "term", intensity_time_limits, num_terms_in_year=num_terms_in_year
     )
-    # Risk-label budget: legacy 4-term fall-centric -1. Eligibility endpoints (opposite
-    # core term) are handled in :func:`shared.get_students_with_max_target_term_in_dataset`.
-    intensity_num_terms_for_target = (
-        {
+    # Match :func:`graduation.compute_target`: four terms per year only, fall-to-spring
+    # paths span one fewer term than ``years * 4`` (see graduation for rationale).
+    if num_terms_in_year == 4:
+        intensity_num_terms = {
             intensity: max(num_terms - 1.0, 1.0)
             for intensity, num_terms in intensity_num_terms.items()
         }
-        if num_terms_in_year == 4
-        else intensity_num_terms
-    )
 
     # 6. Apply intensity-specific time limits and select at-risk student IDs
     # Check if student took more terms than allowed (e.g., full-time students get 12 terms, part-time get 16)
@@ -124,7 +121,7 @@ def compute_target(
                 | df_at[f"{tr_col}_tgt"].isna()
             )
         )
-        for intensity, num_terms in intensity_num_terms_for_target.items()
+        for intensity, num_terms in intensity_num_terms.items()
     ]
     target = np.logical_or.reduce(targets)
 
@@ -135,7 +132,7 @@ def compute_target(
         .astype({"target": "boolean"})
     )
 
-    # 7. Eligibility: pass raw term budgets; shared applies core-term endpoints.
+    # 7. Eligibility (see :func:`shared.get_students_with_max_target_term_in_dataset`):
     intensity_time_limits_for_eligibility = t.cast(
         utils.types.IntensityTimeLimitsType,
         {

--- a/src/edvise/targets/graduation.py
+++ b/src/edvise/targets/graduation.py
@@ -116,6 +116,17 @@ def compute_target(
     intensity_num_terms = utils.data_cleaning.convert_intensity_time_limits(
         "term", intensity_time_limits, num_terms_in_year=num_terms_in_year
     )
+    # Four terms per year only (e.g. fall/winter/spring/summer): a limit of N academic
+    # years from first fall to spring of year N spans N * 4 - 1 terms (the summer after
+    # graduation is outside the window). Two- and three-term calendars do not use this
+    # adjustment here; three-term fall→spring is applied in
+    # :func:`shared.get_students_with_max_target_term_in_dataset` when start season is known.
+    if num_terms_in_year == 4:
+        intensity_num_terms = {
+            intensity: max(num_terms - 1.0, 1.0)
+            for intensity, num_terms in intensity_num_terms.items()
+        }
+
     intensity_time_limits_for_eligibility = t.cast(
         utils.types.IntensityTimeLimitsType,
         {

--- a/src/edvise/targets/graduation.py
+++ b/src/edvise/targets/graduation.py
@@ -116,16 +116,6 @@ def compute_target(
     intensity_num_terms = utils.data_cleaning.convert_intensity_time_limits(
         "term", intensity_time_limits, num_terms_in_year=num_terms_in_year
     )
-    # Four terms per year only (e.g. fall/winter/spring/summer): a limit of N academic
-    # years from first fall to spring of year N spans N * 4 - 1 terms (the summer after
-    # graduation is outside the window). Two- and three-term calendars do not use this
-    # adjustment; their fall–spring paths already align with ``years * num_terms_in_year``.
-    if num_terms_in_year == 4:
-        intensity_num_terms = {
-            intensity: max(num_terms - 1.0, 1.0)
-            for intensity, num_terms in intensity_num_terms.items()
-        }
-
     intensity_time_limits_for_eligibility = t.cast(
         utils.types.IntensityTimeLimitsType,
         {
@@ -133,13 +123,16 @@ def compute_target(
             for intensity, num_terms in intensity_num_terms.items()
         },
     )
+    ckpt_include_cols = student_id_cols + [term_rank_col, enrollment_intensity_col]
+    if "academic_term" in df.columns:
+        ckpt_include_cols = ckpt_include_cols + ["academic_term"]
     df_labelable_students = shared.get_students_with_max_target_term_in_dataset(
         df,
         checkpoint=ft.partial(
             checkpoints.nth_student_terms.first_student_terms_within_cohort,
             student_id_cols=student_id_cols,
             sort_cols=term_rank_col,
-            include_cols=(student_id_cols + [term_rank_col, enrollment_intensity_col]),
+            include_cols=ckpt_include_cols,
             term_is_pre_cohort_col=term_is_pre_cohort_col,
             term_is_core_col="term_is_core",
             exclude_non_core_terms=False,

--- a/src/edvise/targets/shared.py
+++ b/src/edvise/targets/shared.py
@@ -47,7 +47,6 @@ def get_students_with_max_target_term_in_dataset(
         num_terms_in_year: Number of academic terms in one academic year,
             used to convert from year-based time limits to term-based time limits;
             default value assumes FALL, WINTER, SPRING, and SUMMER terms.
-            Windows end on the opposite core term: FALL/SUMMER → SPRING, SPRING/WINTER → FALL.
         student_id_cols: One or multiple columns uniquely identifying students.
         enrollment_intensity_col: Column whose values give students' "enrollment intensity"
             (usually either "FULL-TIME" or "PART-TIME"), for use in applying a time limit.
@@ -56,17 +55,13 @@ def get_students_with_max_target_term_in_dataset(
         term_is_core_col: Boolean column identifying core terms (FALL/SPRING by default).
         academic_term_col: Column with term season labels (FALL, SPRING, SUMMER, …).
     """
-    # Coverage for labeling must reach a core term; summer alone is never enough.
+    # Coverage must reach a core term; a trailing summer alone is never enough.
     if max_term_rank == "infer":
+        max_term_rank = int(df[term_rank_col].max())
         if term_is_core_col in df.columns:
             core_ranks = df.loc[df[term_is_core_col].fillna(False), term_rank_col]
-            max_term_rank = (
-                int(core_ranks.max())
-                if not core_ranks.empty
-                else int(df[term_rank_col].max())
-            )
-        else:
-            max_term_rank = int(df[term_rank_col].max())
+            if not core_ranks.empty:
+                max_term_rank = int(core_ranks.max())
     assert isinstance(max_term_rank, int)  # type guard
 
     student_id_cols = utils.types.to_list(student_id_cols)
@@ -99,16 +94,17 @@ def get_students_with_max_target_term_in_dataset(
                 - 1.0
             )
         )
-    # Trim so windows end on the opposite core term (not the summer after it).
-    # FALL/SUMMER → SPRING; SPRING → FALL (4-term only); WINTER → FALL (no trim).
+    # Season corrections on top of caller budgets (callers already apply 4-term -1):
+    # - 3-term FALL → SPRING (-1); Spring is enough — no later Fall required
+    # - 4-term SUMMER/WINTER: undo blanket -1 (Summer already lands on Spring; Winter→Fall)
     if academic_term_col in df_ckpt.columns:
         season = df_ckpt[academic_term_col].astype("string").str.upper()
-        trim = season.isin(["FALL", "SUMMER"]) & (num_terms_in_year >= 3)
-        trim |= season.eq("SPRING") & (num_terms_in_year == 4)
-        df_ckpt.loc[trim, "student_max_term_rank"] -= 1.0
-    elif num_terms_in_year == 4:
-        # Legacy fall-centric budget when start season is unavailable.
-        df_ckpt["student_max_term_rank"] -= 1.0
+        if num_terms_in_year == 3:
+            df_ckpt.loc[season.eq("FALL"), "student_max_term_rank"] -= 1.0
+        elif num_terms_in_year == 4:
+            df_ckpt.loc[
+                season.isin(["SUMMER", "WINTER"]), "student_max_term_rank"
+            ] += 1.0
     df_out = (
         df_ckpt.loc[
             df_ckpt["student_max_term_rank"].le(max_term_rank),

--- a/src/edvise/targets/shared.py
+++ b/src/edvise/targets/shared.py
@@ -19,6 +19,8 @@ def get_students_with_max_target_term_in_dataset(
     student_id_cols: str | list[str] = "student_id",
     enrollment_intensity_col: str = "student_term_enrollment_intensity",
     term_rank_col: str = "term_rank",
+    term_is_core_col: str = "term_is_core",
+    academic_term_col: str = "academic_term",
 ) -> pd.DataFrame:
     """
     Get set of students in ``checkpoint`` data for which ``df`` includes
@@ -40,17 +42,31 @@ def get_students_with_max_target_term_in_dataset(
         max_term_rank: Maximum term rank value in the full dataset ``df`` , either inferred
             from ``df[term_rank_col]`` itself or as a manually specified value which
             may be different from the actual max value in ``df`` , depending on use case.
+            When ``"infer"``, only core terms (FALL/SPRING) count — a trailing SUMMER
+            cannot make a cohort labelable.
         num_terms_in_year: Number of academic terms in one academic year,
             used to convert from year-based time limits to term-based time limits;
             default value assumes FALL, WINTER, SPRING, and SUMMER terms.
+            Windows end on the opposite core term: FALL/SUMMER → SPRING, SPRING/WINTER → FALL.
         student_id_cols: One or multiple columns uniquely identifying students.
         enrollment_intensity_col: Column whose values give students' "enrollment intensity"
             (usually either "FULL-TIME" or "PART-TIME"), for use in applying a time limit.
         term_rank_col: Column whose values give the absolute integer ranking of a given
             term within the full dataset ``df`` .
+        term_is_core_col: Boolean column identifying core terms (FALL/SPRING by default).
+        academic_term_col: Column with term season labels (FALL, SPRING, SUMMER, …).
     """
+    # Coverage for labeling must reach a core term; summer alone is never enough.
     if max_term_rank == "infer":
-        max_term_rank = int(df[term_rank_col].max())
+        if term_is_core_col in df.columns:
+            core_ranks = df.loc[df[term_is_core_col].fillna(False), term_rank_col]
+            max_term_rank = (
+                int(core_ranks.max())
+                if not core_ranks.empty
+                else int(df[term_rank_col].max())
+            )
+        else:
+            max_term_rank = int(df[term_rank_col].max())
     assert isinstance(max_term_rank, int)  # type guard
 
     student_id_cols = utils.types.to_list(student_id_cols)
@@ -83,6 +99,16 @@ def get_students_with_max_target_term_in_dataset(
                 - 1.0
             )
         )
+    # Trim so windows end on the opposite core term (not the summer after it).
+    # FALL/SUMMER → SPRING; SPRING → FALL (4-term only); WINTER → FALL (no trim).
+    if academic_term_col in df_ckpt.columns:
+        season = df_ckpt[academic_term_col].astype("string").str.upper()
+        trim = season.isin(["FALL", "SUMMER"]) & (num_terms_in_year >= 3)
+        trim |= season.eq("SPRING") & (num_terms_in_year == 4)
+        df_ckpt.loc[trim, "student_max_term_rank"] -= 1.0
+    elif num_terms_in_year == 4:
+        # Legacy fall-centric budget when start season is unavailable.
+        df_ckpt["student_max_term_rank"] -= 1.0
     df_out = (
         df_ckpt.loc[
             df_ckpt["student_max_term_rank"].le(max_term_rank),

--- a/src/edvise/targets/shared.py
+++ b/src/edvise/targets/shared.py
@@ -102,9 +102,9 @@ def get_students_with_max_target_term_in_dataset(
         if num_terms_in_year == 3:
             df_ckpt.loc[season.eq("FALL"), "student_max_term_rank"] -= 1.0
         elif num_terms_in_year == 4:
-            df_ckpt.loc[
-                season.isin(["SUMMER", "WINTER"]), "student_max_term_rank"
-            ] += 1.0
+            df_ckpt.loc[season.isin(["SUMMER", "WINTER"]), "student_max_term_rank"] += (
+                1.0
+            )
     df_out = (
         df_ckpt.loc[
             df_ckpt["student_max_term_rank"].le(max_term_rank),

--- a/tests/preprocessing/targets/pdp/test_graduation.py
+++ b/tests/preprocessing/targets/pdp/test_graduation.py
@@ -268,3 +268,149 @@ def test_graduation_two_three_term_insufficient_max_term_rank_yields_no_labels(
         enrollment_year_col="enrollment_year",
     )
     assert len(obs) == 0
+
+
+def _core_endpoint_student_terms(
+    *,
+    start_term: str,
+    start_rank: int,
+    max_rank: int,
+    years_to_degree: int,
+    final_term_is_core: bool,
+) -> pd.DataFrame:
+    """Minimal student-term rows spanning ``start_rank``..``max_rank`` for eligibility tests."""
+    ranks = list(range(start_rank, max_rank + 1))
+    n = len(ranks)
+    # Filler rows are core FALL; only checkpoint + final seasons matter for these tests.
+    academic_term = ["FALL"] * n
+    term_is_core = [True] * n
+    academic_term[0] = start_term
+    term_is_core[0] = start_term in {"FALL", "SPRING"}
+    # Fall/Summer → Spring; Spring/Winter → Fall.
+    needs_fall = start_term in {"SPRING", "WINTER"}
+    if final_term_is_core:
+        academic_term[-1] = "FALL" if needs_fall else "SPRING"
+        term_is_core[-1] = True
+    else:
+        academic_term[-1] = "SUMMER"
+        term_is_core[-1] = False
+        if n >= 2:
+            # Prior core term: opposite of what the start still needs, so coverage is short.
+            academic_term[-2] = "SPRING" if needs_fall else "FALL"
+            term_is_core[-2] = True
+    return pd.DataFrame(
+        {
+            "student_id": ["01"] * n,
+            "enrollment_intensity": ["FT"] * n,
+            "years_to_degree": [years_to_degree] * n,
+            "enrollment_year": [1] * n,
+            "term_rank": ranks,
+            "term_is_pre_cohort": [False] * n,
+            "term_is_core": term_is_core,
+            "academic_term": academic_term,
+        },
+    ).astype(
+        {
+            "student_id": "string",
+            "enrollment_intensity": "string",
+            "academic_term": "string",
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ["start_term", "num_terms_in_year", "max_rank"],
+    [
+        ("SPRING", 3, 12),
+        ("WINTER", 4, 16),
+    ],
+)
+def test_graduation_spring_like_start_summer_without_fall_not_labelable(
+    start_term, num_terms_in_year, max_rank
+):
+    """Spring/Winter starters need Fall; a trailing Summer is not enough."""
+    df = _core_endpoint_student_terms(
+        start_term=start_term,
+        start_rank=1,
+        max_rank=max_rank,
+        years_to_degree=5,
+        final_term_is_core=False,
+    )
+    obs = graduation.compute_target(
+        df,
+        intensity_time_limits={"FT": [4, "year"]},
+        num_terms_in_year=num_terms_in_year,
+        max_term_rank="infer",
+        student_id_cols="student_id",
+        enrollment_intensity_col="enrollment_intensity",
+        years_to_degree_col="years_to_degree",
+        enrollment_year_col="enrollment_year",
+    )
+    assert len(obs) == 0
+
+
+@pytest.mark.parametrize(
+    ["start_term", "num_terms_in_year", "max_rank"],
+    [
+        ("SPRING", 3, 12),
+        ("WINTER", 4, 16),
+    ],
+)
+def test_graduation_spring_like_start_with_fall_is_labelable(
+    start_term, num_terms_in_year, max_rank
+):
+    """Spring/Winter starters become labelable once Fall exists."""
+    df = _core_endpoint_student_terms(
+        start_term=start_term,
+        start_rank=1,
+        max_rank=max_rank,
+        years_to_degree=5,
+        final_term_is_core=True,
+    )
+    obs = graduation.compute_target(
+        df,
+        intensity_time_limits={"FT": [4, "year"]},
+        num_terms_in_year=num_terms_in_year,
+        max_term_rank="infer",
+        student_id_cols="student_id",
+        enrollment_intensity_col="enrollment_intensity",
+        years_to_degree_col="years_to_degree",
+        enrollment_year_col="enrollment_year",
+    )
+    assert len(obs) == 1
+    assert bool(obs.loc["01"]) is True
+
+
+@pytest.mark.parametrize(
+    ["start_term", "num_terms_in_year", "max_rank"],
+    [
+        # Fall/Summer → Spring: years*num_terms - 1
+        ("FALL", 3, 11),
+        ("SUMMER", 3, 11),
+        ("FALL", 4, 15),
+        ("SUMMER", 4, 15),
+    ],
+)
+def test_graduation_fall_like_start_ends_at_spring_not_summer(
+    start_term, num_terms_in_year, max_rank
+):
+    """Fall/Summer starters need Spring; they should not require the following Summer."""
+    df = _core_endpoint_student_terms(
+        start_term=start_term,
+        start_rank=1,
+        max_rank=max_rank,
+        years_to_degree=4,
+        final_term_is_core=True,
+    )
+    obs = graduation.compute_target(
+        df,
+        intensity_time_limits={"FT": [4, "year"]},
+        num_terms_in_year=num_terms_in_year,
+        max_term_rank="infer",
+        student_id_cols="student_id",
+        enrollment_intensity_col="enrollment_intensity",
+        years_to_degree_col="years_to_degree",
+        enrollment_year_col="enrollment_year",
+    )
+    assert len(obs) == 1
+    assert bool(obs.loc["01"]) is False

--- a/tests/preprocessing/targets/pdp/test_graduation.py
+++ b/tests/preprocessing/targets/pdp/test_graduation.py
@@ -384,17 +384,18 @@ def test_graduation_spring_like_start_with_fall_is_labelable(
 @pytest.mark.parametrize(
     ["start_term", "num_terms_in_year", "max_rank"],
     [
-        # Fall/Summer → Spring: years*num_terms - 1
+        # Fall → Spring: trim -1 so Spring is enough (no following Summer/Fall required)
         ("FALL", 3, 11),
-        ("SUMMER", 3, 11),
         ("FALL", 4, 15),
-        ("SUMMER", 4, 15),
+        # Summer → Spring: untrimmed already lands on Spring (no -1)
+        ("SUMMER", 3, 12),
+        ("SUMMER", 4, 16),
     ],
 )
 def test_graduation_fall_like_start_ends_at_spring_not_summer(
     start_term, num_terms_in_year, max_rank
 ):
-    """Fall/Summer starters need Spring; they should not require the following Summer."""
+    """Fall/Summer starters need Spring; Fall must not require the following Summer."""
     df = _core_endpoint_student_terms(
         start_term=start_term,
         start_rank=1,
@@ -414,3 +415,51 @@ def test_graduation_fall_like_start_ends_at_spring_not_summer(
     )
     assert len(obs) == 1
     assert bool(obs.loc["01"]) is False
+
+
+def test_graduation_summer_start_four_term_does_not_over_trim():
+    """Summer@rank 4, 4y/4-term: untrimmed=19 (Spring Y5); trimming would hit Winter."""
+    # Minimal rows: checkpoint Summer rank 4, core Spring at 19 as latest coverage.
+    n = 19
+    academic_term = ["FALL"] * n
+    term_is_core = [True] * n
+    academic_term[3] = "SUMMER"  # rank 4
+    term_is_core[3] = False
+    academic_term[-1] = "SPRING"  # rank 19
+    term_is_core[-1] = True
+    # Avoid a later false "max core" from filler FALL after spring endpoint.
+    for i in range(4, n - 1):
+        academic_term[i] = "WINTER"
+        term_is_core[i] = False
+    df = pd.DataFrame(
+        {
+            "student_id": ["01"] * n,
+            "enrollment_intensity": ["FT"] * n,
+            "years_to_degree": [5] * n,
+            "enrollment_year": [1] * n,
+            "term_rank": list(range(1, n + 1)),
+            "term_is_pre_cohort": [False] * n,
+            "term_is_core": term_is_core,
+            "academic_term": academic_term,
+        },
+    ).astype(
+        {
+            "student_id": "string",
+            "enrollment_intensity": "string",
+            "academic_term": "string",
+        }
+    )
+    # First within-cohort term must be the Summer checkpoint (rank 4).
+    df.loc[df["term_rank"] < 4, "term_is_pre_cohort"] = True
+    obs = graduation.compute_target(
+        df,
+        intensity_time_limits={"FT": [4, "year"]},
+        num_terms_in_year=4,
+        max_term_rank="infer",
+        student_id_cols="student_id",
+        enrollment_intensity_col="enrollment_intensity",
+        years_to_degree_col="years_to_degree",
+        enrollment_year_col="enrollment_year",
+    )
+    assert len(obs) == 1
+    assert bool(obs.loc["01"]) is True


### PR DESCRIPTION
## Description
TLDR: Prevent spring/winter cohorts from entering training when only a trailing summer is available; fall/summer starts end at spring.

The issue arises when Spring 2022-23 is included in training for 2 institutions who only have 3 terms in a year (fall, spring, summer) and a 4 year graduation timeline. These students start Spring 2023- so, they should graduate Fall 2026.
We do NOT have that data for these 2 institutions- we only have through summer 2026. So they should NOT be included in the training cohorts. Possibly, bc we DO have data for summer 2026- yet it's labeled as 2026-27 - this could be mistaken for  "enrolled enough time to graduate," and the illusion of a "2027 term" is enough to include them in training. However, this isn't correct, and we need more guardrails around this. 

Technically, this cohort should be included during inference, and this messes with the inference run too, bc the cohort is "auto removed" due to being linked to a training cohort as "stop-outs," even though we don't even actually know if they graduated just yet - so they should be in the inference output. Instead, they're in the training, and the whole class is basically inaccurately labeled "need support."

Now, spring starts always require a FALL term in their 4Y timeline to determine if they've graduated or not, not just any term (so a summer term wouldn't work) and fall starts we look for a SPRING term to determine if they've graduated - i.e the summer before fall is not enough. We need to check for CORE terms at the end of the timeline. 

## Asana Task
https://app.asana.com/1/6325821815997/project/1211248293138281/task/1216834318530780

## Deployment Readiness\*

### Testing

Describe or check:

- [x] Created or updated unit, feature, and/or integration tests  
- [x] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [x]  No special deployment steps required

### Rollback Plan

Describe or check:

- [x]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*
Tested in dev.

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional