### PR TITLE
fix(genai): allow rewriting rationale on manifest mapping overrides

### DIFF
--- a/src/edvise/genai/mapping/schema_mapping_agent/manifest/hitl/override.py
+++ b/src/edvise/genai/mapping/schema_mapping_agent/manifest/hitl/override.py
@@ -33,6 +33,8 @@ class ManifestMappingOverrideRequest:
     target_field: str
     corrected: FieldMappingRecord
     reviewer_notes: str | None = None
+    rationale: str | None = None
+    """Explicit rationale override — omit to preserve the original manifest rationale."""
 
 
 def unmapped_field_mapping_record(target_field: str) -> FieldMappingRecord:
@@ -99,11 +101,18 @@ def _parse_override_entry(raw: Any, *, index: int) -> ManifestMappingOverrideReq
     notes = str(reviewer_notes).strip() if reviewer_notes is not None else None
     if notes == "":
         notes = None
+
+    rationale = raw.get("rationale")
+    resolved_rationale = str(rationale).strip() if rationale is not None else None
+    if resolved_rationale == "":
+        resolved_rationale = None
+
     return ManifestMappingOverrideRequest(
         entity_type=entity_type,
         target_field=target_field,
         corrected=corrected,
         reviewer_notes=notes,
+        rationale=resolved_rationale,
     )
 
 
@@ -117,7 +126,8 @@ def load_overrides_json(path: str | Path) -> list[ManifestMappingOverrideRequest
           "entity_type": "cohort",
           "target_field": "learner_id",
           "correction": { ... FieldMappingRecord ... },
-          "reviewer_notes": "optional"
+          "reviewer_notes": "optional",
+          "rationale": "optional — rewrites rationale instead of preserving the original"
         }
 
     Or omit ``correction`` and set ``"unmap": true`` to leave the field unmapped.
@@ -179,6 +189,7 @@ def override_manifest_mappings(
             original_db_run_id=original_db_run_id,
             original_task_run_id=original_task_run_id,
             reviewer_notes=req.reviewer_notes,
+            rationale=req.rationale,
             institution_id=institution_id,
         )
     return len(overrides)
@@ -195,13 +206,15 @@ def override_manifest_mapping(
     original_db_run_id: str,
     original_task_run_id: str | None = None,
     reviewer_notes: str | None = None,
+    rationale: str | None = None,
     institution_id: str | None = None,
 ) -> None:
     """
     Apply a single manifest mapping override on local disk paths.
 
-    See :func:`apply_manifest_mapping_override` for merge semantics (original ``confidence`` and
-    ``rationale`` are preserved; ``review_status`` becomes ``corrected_by_override``).
+    See :func:`apply_manifest_mapping_override` for merge semantics (original ``confidence``
+    is always preserved; ``rationale`` is preserved unless an explicit ``rationale`` is
+    passed here; ``review_status`` becomes ``corrected_by_override``).
     """
     override_manifest_mappings(
         manifest_path,
@@ -215,6 +228,7 @@ def override_manifest_mapping(
                     else FieldMappingRecord.model_validate(corrected)
                 ),
                 reviewer_notes=reviewer_notes,
+                rationale=rationale,
             )
         ],
         override_log_path=override_log_path,

--- a/src/edvise/genai/mapping/schema_mapping_agent/manifest/hitl/resolver.py
+++ b/src/edvise/genai/mapping/schema_mapping_agent/manifest/hitl/resolver.py
@@ -132,15 +132,20 @@ def _merge_mapping_override(
     corrected: FieldMappingRecord,
     *,
     reviewer_notes: str | None,
+    rationale: str | None = None,
 ) -> FieldMappingRecord:
     """
     Apply a manifest mapping override: use ``corrected`` for structural mapping fields,
-    keep ``confidence`` and ``rationale`` from ``original``, set review telemetry.
+    keep ``confidence`` and ``rationale`` from ``original`` by default, set review telemetry.
+
+    ``rationale`` lets the caller explicitly rewrite the rationale to reflect *why* the
+    override was needed (e.g. the original agent's rationale describing a mapping that
+    turned out to be wrong) — omit to preserve ``original.rationale`` as before.
     """
     return corrected.model_copy(
         update={
             "confidence": original.confidence,
-            "rationale": original.rationale,
+            "rationale": rationale if rationale is not None else original.rationale,
             "review_status": ReviewStatus.corrected_by_override,
             "reviewer_notes": reviewer_notes,
         }
@@ -300,6 +305,7 @@ def apply_manifest_mapping_override(
     original_db_run_id: str,
     original_task_run_id: str | None = None,
     reviewer_notes: str | None = None,
+    rationale: str | None = None,
     override_task_run_id: str | None = None,
     institution_id: str | None = None,
 ) -> None:
@@ -307,8 +313,10 @@ def apply_manifest_mapping_override(
     Apply a post-gate manifest mapping override and append :class:`MappingOverrideEvent`.
 
     The written mapping row uses ``corrected_field_mapping`` for all fields except
-    ``confidence`` and ``rationale``, which are taken from the existing manifest entry.
-    Sets ``review_status`` to :attr:`ReviewStatus.corrected_by_override`.
+    ``confidence`` and ``rationale``, which are taken from the existing manifest entry
+    by default. Pass ``rationale`` to explicitly rewrite the rationale instead of
+    preserving the original agent's (now-outdated) explanation. Sets ``review_status``
+    to :attr:`ReviewStatus.corrected_by_override`.
 
     ``manifest_path`` may be a :class:`MappingManifestEnvelope` or a standalone
     :class:`FieldMappingManifest`; when standalone, pass ``institution_id`` (required).
@@ -340,7 +348,9 @@ def apply_manifest_mapping_override(
             f"override target {target_field!r}"
         )
 
-    merged = _merge_mapping_override(original, corrected, reviewer_notes=reviewer_notes)
+    merged = _merge_mapping_override(
+        original, corrected, reviewer_notes=reviewer_notes, rationale=rationale
+    )
     fm.mappings[idx] = merged
     _save_manifest_for_entity(manifest_path, env_wrapper, fm, entity_key)
 

--- a/tests/genai/mapping/schema_mapping_agent/hitl/test_apply_manifest_mapping_override.py
+++ b/tests/genai/mapping/schema_mapping_agent/hitl/test_apply_manifest_mapping_override.py
@@ -87,6 +87,46 @@ def test_apply_manifest_mapping_override_preserves_confidence_and_rationale(
     assert e0.override_type == "manifest_mapping"
 
 
+def test_apply_manifest_mapping_override_can_rewrite_rationale(
+    tmp_path: Path,
+) -> None:
+    tmp = tmp_path
+    original = _fmr()
+    fm = FieldMappingManifest(
+        entity_type="cohort",
+        target_schema="RawEdviseStudentDataSchema",
+        mappings=[original],
+    )
+    manifest_path = write_sma_manifest_artifact(tmp, fm, basename="m.json")
+    override_log_path = tmp / "mapping_override_log.json"
+
+    corrected = _fmr(
+        source_column="student_id_v2",
+        confidence=0.99,
+        rationale="should not appear either",
+    )
+
+    apply_manifest_mapping_override(
+        manifest_path,
+        "cohort",
+        "learner_id",
+        corrected,
+        override_log_path=override_log_path,
+        overridden_by="ops",
+        original_db_run_id="db-42",
+        reviewer_notes="fixed column",
+        rationale="rewritten: original mapping pointed at the wrong column",
+        institution_id="u9",
+    )
+
+    out = read_pydantic_json(manifest_path, FieldMappingManifest)
+    m0 = out.mappings[0]
+    assert m0.source_column == "student_id_v2"
+    assert m0.confidence == 0.4  # still preserved from original
+    assert m0.rationale == "rewritten: original mapping pointed at the wrong column"
+    assert m0.review_status == ReviewStatus.corrected_by_override
+
+
 def test_apply_manifest_mapping_override_envelope(tmp_path: Path) -> None:
     tmp = tmp_path
     original = _fmr()


### PR DESCRIPTION
## Summary
- `apply_manifest_mapping_override` always preserved the original agent's `rationale`/`confidence` verbatim, even when the correction made the original rationale inaccurate (e.g. redirecting a field's `source_column` because the original mapping was wrong).
- Adds an optional `rationale` parameter (default `None` preserves the existing preserve-by-default behavior) threaded through `apply_manifest_mapping_override`, `ManifestMappingOverrideRequest`, `override_manifest_mapping(s)`, and the JSON overrides-file loader (`rationale` key), so reviewers can explicitly rewrite the rationale to explain the override.
- `confidence` is unaffected and continues to be preserved from the original manifest entry.

## Test plan
- [x] `uv run pytest tests/genai/mapping/schema_mapping_agent/hitl/ -q` — 28 passed
- [x] Added `test_apply_manifest_mapping_override_can_rewrite_rationale` covering the new explicit-rationale path alongside the existing preserve-by-default test

Made with [Cursor](https://cursor.com)