### PR TITLE
fix(genai): wire materialized SMA transform hooks into field executor

### DIFF
--- a/src/edvise/genai/mapping/schema_mapping_agent/execution/field_executor.py
+++ b/src/edvise/genai/mapping/schema_mapping_agent/execution/field_executor.py
@@ -34,7 +34,7 @@ import json
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Callable, Optional, Type
+from typing import Any, Callable, Optional, Type, cast
 
 import pandas as pd
 
@@ -952,7 +952,9 @@ def _load_sma_transform_hook_function(
             "(run materialize_hook_specs_to_file before execution)."
         )
     if not hook_spec.functions:
-        raise ExecutionError(f"hook_spec for '{hook_spec.file}' has no functions to load")
+        raise ExecutionError(
+            f"hook_spec for '{hook_spec.file}' has no functions to load"
+        )
 
     path = resolve_hook_module_path(hook_spec.file, root=modules_root)
     module = module_cache.get(path)
@@ -970,7 +972,7 @@ def _load_sma_transform_hook_function(
     fn = getattr(module, fn_name, None)
     if not callable(fn):
         raise ExecutionError(f"Module {path} missing callable {fn_name!r}")
-    return fn
+    return cast(Callable[[pd.Series], pd.Series], fn)
 
 
 # =============================================================================

--- a/src/edvise/genai/mapping/schema_mapping_agent/execution/field_executor.py
+++ b/src/edvise/genai/mapping/schema_mapping_agent/execution/field_executor.py
@@ -29,17 +29,20 @@ Key design principles:
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Optional, Type
+from typing import Any, Callable, Optional, Type
 
 import pandas as pd
 
 from edvise.genai.mapping.shared.grain.dedup_execution import (
     apply_sma_grain_resolution_payload,
 )
+from edvise.genai.mapping.shared.hitl.hook_spec.paths import resolve_hook_module_path
+from edvise.genai.mapping.shared.hitl.hook_spec.schemas import HookSpec
 from edvise.genai.mapping.schema_mapping_agent.manifest.schemas import (
     FieldMappingManifest,
     FieldMappingRecord,
@@ -921,6 +924,56 @@ def validate_source_columns_for_execute(
 
 
 # =============================================================================
+# Materialized hook loading (SMA transform hooks)
+# =============================================================================
+
+
+def _load_sma_transform_hook_function(
+    hook_spec: HookSpec,
+    *,
+    modules_root: str | Path,
+    module_cache: dict[Path, Any],
+) -> Callable[[pd.Series], pd.Series]:
+    """
+    Dynamically import the materialized ``transform_hooks.py`` module named by ``hook_spec.file``
+    and return the ``Series -> Series`` callable named by ``hook_spec.functions[0].name``.
+
+    Mirrors identity_agent.execution.contract_utilities._load_grain_dedup_hook_from_hook_spec
+    and identity_agent.hitl.resolver.validate_hook's dynamic-import pattern — SMA transform
+    hooks never had an execution-side loader until this was added; generation and materialization
+    (edvise.genai.mapping.schema_mapping_agent.transformation.hitl.hook_generation, reusing
+    identity_agent.hitl.hook_generation.materialize) already worked on their own.
+
+    ``module_cache`` avoids re-importing the same file for every field that shares one module.
+    """
+    if not hook_spec.file:
+        raise ExecutionError(
+            "hook_spec.file is required to load a materialized transform hook "
+            "(run materialize_hook_specs_to_file before execution)."
+        )
+    if not hook_spec.functions:
+        raise ExecutionError(f"hook_spec for '{hook_spec.file}' has no functions to load")
+
+    path = resolve_hook_module_path(hook_spec.file, root=modules_root)
+    module = module_cache.get(path)
+    if module is None:
+        if not path.exists():
+            raise ExecutionError(f"Materialized hook module not found: {path}")
+        spec = importlib.util.spec_from_file_location("_sma_transform_hooks", path)
+        if spec is None or spec.loader is None:
+            raise ExecutionError(f"Could not load hook module spec for {path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        module_cache[path] = module
+
+    fn_name = hook_spec.functions[0].name
+    fn = getattr(module, fn_name, None)
+    if not callable(fn):
+        raise ExecutionError(f"Module {path} missing callable {fn_name!r}")
+    return fn
+
+
+# =============================================================================
 # Transformation map execution
 # =============================================================================
 
@@ -939,6 +992,7 @@ def execute_transformation_map(
     ia_source_keys: list[str] | None = None,
     sma_grain_resolution_path: Path | None = None,
     sma_manifest_path: Path | None = None,
+    hook_modules_root: str | Path | None = None,
 ) -> ExecutionResult:
     """
     Execute a TransformationMap against resolved DataFrames.
@@ -970,6 +1024,11 @@ def execute_transformation_map(
             all grain mismatches are treated as within-grain multiplicity.
         sma_grain_resolution_path: Optional resolver output to shrink ``base_df`` before execution.
         sma_manifest_path: Optional path stored into SMA grain HITL metadata (tooling only).
+        hook_modules_root: Root directory to resolve ``FieldTransformationPlan.hook_spec.file``
+            under (the same ``repo_root`` passed to ``materialize_hook_specs_to_file``). When a
+            ``hook_required`` plan carries a populated ``hook_spec``, the executor dynamically
+            imports the materialized function and runs it instead of treating the field as a gap.
+            Omit to keep the previous gap-only behavior (e.g. hook not yet generated/approved).
 
     Returns:
         ExecutionResult with assembled target DataFrame and execution metadata
@@ -1053,6 +1112,7 @@ def execute_transformation_map(
     gaps: list[str] = []
     skipped: list[str] = []
     executed: list[str] = []
+    hook_module_cache: dict[Path, Any] = {}
 
     n_plans = len(transformation_map.plans)
     logger.info(
@@ -1070,7 +1130,10 @@ def execute_transformation_map(
             )
             continue
 
-        if plan.hook_required:
+        # A hook_required plan is only executable once a materialized hook has been
+        # attached (plan.hook_spec, set by the pipeline after hook generation +
+        # materialize_hook_specs_to_file). Without it, it's still an unresolved gap.
+        if plan.hook_required and (plan.hook_spec is None or hook_modules_root is None):
             msg = f"Field '{target}' — hook_required (no covering utility chain; see reviewer_notes)"
             logger.warning(f"[{i}/{n_plans}] {target} — {msg}")
             if raise_on_gap:
@@ -1078,7 +1141,7 @@ def execute_transformation_map(
             gaps.append(target)
             continue
 
-        if not plan.steps and not record.source_column:
+        if not plan.hook_required and not plan.steps and not record.source_column:
             logger.debug(f"[{i}/{n_plans}] {target} — unmappable, skipping")
             skipped.append(target)
             continue
@@ -1098,13 +1161,31 @@ def execute_transformation_map(
                     dtype="object",
                 )
 
-            # --- 2. Run transformation steps (pure Series → Series) ---
-            for j, step in enumerate(plan.steps, 1):
-                logger.debug(
-                    f"[{i}/{n_plans}] {target} — step {j}/{len(plan.steps)}: "
-                    f"{step.function_name}"
+            # --- 2. Run transformation steps, or the materialized hook ---
+            if plan.hook_required:
+                assert plan.hook_spec is not None and hook_modules_root is not None
+                hook_fn = _load_sma_transform_hook_function(
+                    plan.hook_spec,
+                    modules_root=hook_modules_root,
+                    module_cache=hook_module_cache,
                 )
-                s = _execute_step(step, s, base_df)
+                logger.debug(
+                    f"[{i}/{n_plans}] {target} — running materialized hook "
+                    f"{plan.hook_spec.functions[0].name}"
+                )
+                s = hook_fn(s)
+                if not isinstance(s, pd.Series):
+                    raise ExecutionError(
+                        f"Hook '{plan.hook_spec.functions[0].name}' for '{target}' must return "
+                        f"a pandas Series, got {type(s).__name__}"
+                    )
+            else:
+                for j, step in enumerate(plan.steps, 1):
+                    logger.debug(
+                        f"[{i}/{n_plans}] {target} — step {j}/{len(plan.steps)}: "
+                        f"{step.function_name}"
+                    )
+                    s = _execute_step(step, s, base_df)
 
             # --- 3. Reduce to one value per entity ---
             if record.row_selection is not None:
@@ -1116,7 +1197,8 @@ def execute_transformation_map(
 
             result_cols[target] = s
             executed.append(target)
-            logger.info(f"[{i}/{n_plans}] ✓ {target} — {len(s)} rows")
+            via = " (via materialized hook)" if plan.hook_required else ""
+            logger.info(f"[{i}/{n_plans}] ✓ {target} — {len(s)} rows{via}")
 
         except ExecutionGapError:
             gaps.append(target)

--- a/src/edvise/genai/mapping/schema_mapping_agent/grain_resolution/runner.py
+++ b/src/edvise/genai/mapping/schema_mapping_agent/grain_resolution/runner.py
@@ -197,6 +197,7 @@ def execute_transformation_map_for_sma_run(
     manifest_map_path: Path,
     grain_hitl_path: Path,
     active_grain_resolution_root: Path | None = None,
+    hook_modules_root: Path | None = None,
 ) -> Any:
     """Run SMA execution with grain paths (HITL, IA keys, optional ``sma_grain_resolution_*.json``).
 
@@ -246,6 +247,7 @@ def execute_transformation_map_for_sma_run(
             ia_source_keys=ia_keys,
             sma_grain_resolution_path=resolution_path,
             sma_manifest_path=manifest_map_path,
+            hook_modules_root=hook_modules_root,
         )
     except GrainReconciliationRequired as exc:
         run_grain_reconciliation_gate(
@@ -314,6 +316,7 @@ def run_onboard_gate_2_entity_with_grain_uc(
     grain_hitl_path: Path,
     poll_interval_seconds: int,
     timeout_seconds: int,
+    hook_modules_root: Path | None = None,
 ) -> tuple[Any, Any]:
     """Execute one entity map; on grain mismatch register ``sma_gate_2_grain``, poll UC, resolve.
 
@@ -342,6 +345,7 @@ def run_onboard_gate_2_entity_with_grain_uc(
                 enriched_contract=enriched_contract,
                 manifest_map_path=manifest_map_path,
                 grain_hitl_path=grain_hitl_path,
+                hook_modules_root=hook_modules_root,
             )
             return result, manifest_cur
         except SmaGrainHitlPending as pend:

--- a/src/edvise/genai/mapping/schema_mapping_agent/transformation/hitl/hook_generation/__init__.py
+++ b/src/edvise/genai/mapping/schema_mapping_agent/transformation/hitl/hook_generation/__init__.py
@@ -3,6 +3,7 @@
 from edvise.genai.mapping.schema_mapping_agent.transformation.hitl.hook_generation.generate import (
     generate_sma_transform_hook_preview_rows_for_entity,
     generate_sma_transform_hook_spec,
+    load_hook_spec_rows_from_sma_preview_path,
     load_hook_specs_from_sma_preview_path,
 )
 from edvise.genai.mapping.schema_mapping_agent.transformation.hitl.hook_generation.prompt import (
@@ -22,6 +23,7 @@ __all__ = [
     "generate_sma_transform_hook_preview_rows_for_entity",
     "generate_sma_transform_hook_spec",
     "is_manifest_record_unmapped",
+    "load_hook_spec_rows_from_sma_preview_path",
     "load_hook_specs_from_sma_preview_path",
     "manifest_mapping_for_target",
     "sma_transform_hook_item_id",

--- a/src/edvise/genai/mapping/schema_mapping_agent/transformation/hitl/hook_generation/generate.py
+++ b/src/edvise/genai/mapping/schema_mapping_agent/transformation/hitl/hook_generation/generate.py
@@ -142,8 +142,26 @@ def load_hook_specs_from_sma_preview_path(path: str | Path) -> list[HookSpec]:
     return out
 
 
+def load_hook_spec_rows_from_sma_preview_path(path: str | Path) -> list[dict[str, Any]]:
+    """
+    Read a written preview JSON and return its raw ``specs`` rows (``item_id``, ``hook_spec``,
+    ``review_context``) — the post-HITL-approval source of truth, since reviewers may edit the
+    drafted function in Streamlit before ``sma_gate_2_hook_preview`` clears.
+
+    Use with :func:`~edvise.genai.mapping.schema_mapping_agent.transformation.hitl.hook_required_hitl.attach_materialized_hook_specs_to_plans`
+    to write each row's ``hook_spec`` back onto its matching ``FieldTransformationPlan``
+    (keyed by ``review_context.target_field``) after materialization, so the executor can call it.
+    """
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    specs_raw = data.get("specs")
+    if not isinstance(specs_raw, list):
+        return []
+    return [row for row in specs_raw if isinstance(row, dict)]
+
+
 __all__ = [
     "generate_sma_transform_hook_preview_rows_for_entity",
     "generate_sma_transform_hook_spec",
+    "load_hook_spec_rows_from_sma_preview_path",
     "load_hook_specs_from_sma_preview_path",
 ]

--- a/src/edvise/genai/mapping/schema_mapping_agent/transformation/hitl/hook_required_hitl.py
+++ b/src/edvise/genai/mapping/schema_mapping_agent/transformation/hitl/hook_required_hitl.py
@@ -209,12 +209,70 @@ def apply_transformation_hook_hitl_resolutions(
     return out
 
 
+def attach_materialized_hook_specs_to_plans(
+    transformation_data: dict[str, Any],
+    *,
+    entity_type: Literal["cohort", "course"],
+    preview_rows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """
+    Patch a deep copy of ``transformation_data``: for each hook-preview row whose
+    ``review_context.target_field`` matches a ``hook_required`` plan in ``entity_type``, set
+    ``plan['hook_spec']`` to that row's (post-approval) ``hook_spec``.
+
+    Call this once per entity after ``materialize_hook_specs_to_file`` (passing rows read back
+    via ``load_hook_spec_rows_from_sma_preview_path`` so reviewer edits made during the
+    ``sma_gate_2_hook_preview`` HITL wait are picked up) and before writing
+    ``transformation_map.json``. Without this, ``hook_required`` plans have no pointer to the
+    materialized function and the field executor treats them as gaps even though the hook
+    file exists on disk.
+
+    ``hook_required`` is intentionally left ``True`` — it still means "no built-in utility
+    chain covers this field"; ``hook_spec`` is what tells the executor a materialized function
+    is now available to run instead of a utility chain.
+    """
+    out: dict[str, Any] = json.loads(json.dumps(transformation_data))
+    tmaps = out.get("transformation_maps")
+    if not isinstance(tmaps, dict):
+        return out
+    plans = _plans_from_entity_section(tmaps.get(entity_type))
+    if not plans:
+        return out
+
+    for row in preview_rows:
+        ctx = row.get("review_context") or {}
+        if not isinstance(ctx, dict):
+            continue
+        if str(ctx.get("entity_type") or "") != entity_type:
+            continue
+        tf = str(ctx.get("target_field") or "").strip()
+        if not tf:
+            continue
+        hook_spec = row.get("hook_spec")
+        if not isinstance(hook_spec, dict):
+            continue
+        ix = _find_plan_index(plans, tf)
+        if ix is None:
+            logger.warning(
+                "Hook preview row %s targets unknown field %s (%s) — skipping",
+                row.get("item_id"),
+                tf,
+                entity_type,
+            )
+            continue
+        if plans[ix].get("hook_required"):
+            plans[ix]["hook_spec"] = hook_spec
+
+    return out
+
+
 __all__ = [
     "InstitutionSMATransformationHookHITLItems",
     "SMATransformationHookHITLItem",
     "SMATransformationHookHITLOption",
     "SMATransformationHookResolution",
     "apply_transformation_hook_hitl_resolutions",
+    "attach_materialized_hook_specs_to_plans",
     "build_transformation_hook_hitl_envelope_for_entity",
     "check_transformation_hook_hitl_gate",
     "default_transformation_hook_hitl_options",

--- a/src/edvise/genai/mapping/schema_mapping_agent/transformation/schemas.py
+++ b/src/edvise/genai/mapping/schema_mapping_agent/transformation/schemas.py
@@ -10,6 +10,7 @@ from pydantic import Field, field_validator, model_validator
 from edvise.genai.mapping.shared.hitl.confidence import (
     PIPELINE_HITL_CONFIDENCE_THRESHOLD,
 )
+from edvise.genai.mapping.shared.hitl.hook_spec.schemas import HookSpec
 from edvise.genai.mapping.shared.pipeline_artifacts import default_pipeline_version
 
 from ..manifest.schemas import (
@@ -455,7 +456,20 @@ class FieldTransformationPlan(StrictBaseModel):
             "a built-in transform). Include a full explanation in reviewer_notes: what "
             "transformation is needed, what was attempted, and why no existing utility covers it. "
             "hook_required is a plan-level flag — not a step type. steps may be empty or contain "
-            "a best-effort partial chain."
+            "a best-effort partial chain. Omit hook_spec here — the pipeline attaches it after "
+            "hook generation/materialization (see FieldTransformationPlan.hook_spec)."
+        ),
+    )
+    hook_spec: Optional[HookSpec] = Field(
+        default=None,
+        description=(
+            "Pipeline-populated (never set by the agent): points to the materialized "
+            "transform_hooks.py function that implements this field's custom Series -> Series "
+            "logic, attached after generate_sma_transform_hook_spec/materialize_hook_specs_to_file "
+            "run for a hook_required plan. When present, the field executor dynamically imports "
+            "hook_spec.file and calls hook_spec.functions[0].name on the resolved source Series "
+            "instead of treating the plan as an execution gap. Null while the hook is still "
+            "pending generation/approval."
         ),
     )
     flagged_steps: Optional[List[FlaggedStep]] = Field(
@@ -489,6 +503,10 @@ class FieldTransformationPlan(StrictBaseModel):
                 raise ValueError(
                     "hitl_options must be omitted (null) when hook_required is true"
                 )
+        if self.hook_spec is not None and self.hook_required is not True:
+            raise ValueError(
+                "hook_spec must be omitted (null) unless hook_required is true"
+            )
 
         if (
             self.confidence is not None

--- a/src/edvise/genai/mapping/scripts/edvise_genai_sma.py
+++ b/src/edvise/genai/mapping/scripts/edvise_genai_sma.py
@@ -30,8 +30,11 @@ After Step 2b, ``gate_2`` registers ``sma_gate_2_transformation_review`` when pl
 ``sma_gate_2_hook_preview`` for ``HookSpec`` previews
 (``cohort_transformation_hook_preview.json`` / ``course_transformation_hook_preview.json``) for plans
 with ``hook_required: true`` (set in Step 2b or via transformation review option 3), then
-materializes ``transform_hooks.py`` after UC approval. When manifest grain is stricter than cleaned
-row count, ``sma_gate_2_grain`` gates ``cohort_sma_grain_hitl.json`` / ``course_sma_grain_hitl.json``
+materializes ``transform_hooks.py`` after UC approval and attaches each materialized
+``hook_spec`` back onto its plan (``attach_materialized_hook_specs_to_plans``) so Step 2c's
+executor can dynamically import and call the generated function instead of treating the field
+as a gap. When manifest grain is stricter than cleaned row count, ``sma_gate_2_grain`` gates
+``cohort_sma_grain_hitl.json`` / ``course_sma_grain_hitl.json``
 (see :mod:`edvise.genai.mapping.schema_mapping_agent.grain_resolution`).
 """
 
@@ -960,8 +963,12 @@ def run_onboard_gate_2(
     from edvise.genai.mapping.identity_agent.hitl.schemas import HITLDomain
     from edvise.genai.mapping.schema_mapping_agent.transformation.hitl.hook_generation import (
         generate_sma_transform_hook_preview_rows_for_entity,
+        load_hook_spec_rows_from_sma_preview_path,
         load_hook_specs_from_sma_preview_path,
         write_sma_transform_hook_preview_json,
+    )
+    from edvise.genai.mapping.schema_mapping_agent.transformation.hitl.hook_required_hitl import (
+        attach_materialized_hook_specs_to_plans,
     )
 
     LOGGER.info("[onboard/gate_2] Transform hook generation (preview)")
@@ -1029,6 +1036,34 @@ def run_onboard_gate_2(
             "[onboard/gate_2] Materialized transform_hooks.py (%d HookSpec(s))",
             len(preview_hook_specs),
         )
+        # Read back the (possibly reviewer-edited) preview rows and attach each hook_spec to
+        # its matching hook_required plan — without this, hook_required never clears/points
+        # anywhere and the executor treats the field as an unresolved gap even though the
+        # materialized function above is ready to run.
+        cohort_hook_rows = load_hook_spec_rows_from_sma_preview_path(
+            paths.cohort_transformation_hook_preview
+        )
+        course_hook_rows = load_hook_spec_rows_from_sma_preview_path(
+            paths.course_transformation_hook_preview
+        )
+        if cohort_hook_rows:
+            transformation_data = attach_materialized_hook_specs_to_plans(
+                transformation_data,
+                entity_type="cohort",
+                preview_rows=cohort_hook_rows,
+            )
+        if course_hook_rows:
+            transformation_data = attach_materialized_hook_specs_to_plans(
+                transformation_data,
+                entity_type="course",
+                preview_rows=course_hook_rows,
+            )
+        LOGGER.info(
+            "[onboard/gate_2] Attached hook_spec to %d plan(s) — cohort=%d course=%d",
+            len(cohort_hook_rows) + len(course_hook_rows),
+            len(cohort_hook_rows),
+            len(course_hook_rows),
+        )
 
     tmaps = transformation_data.get("transformation_maps") or {}
     for _entity in ("cohort", "course"):
@@ -1085,6 +1120,7 @@ def run_onboard_gate_2(
         grain_hitl_path=paths.run_root / "cohort_sma_grain_hitl.json",
         poll_interval_seconds=DEFAULT_HITL_POLL_INTERVAL_SECONDS,
         timeout_seconds=DEFAULT_HITL_POLL_TIMEOUT_SECONDS,
+        hook_modules_root=paths.run_root,
     )
     course_manifest = reload_field_manifest_entity(paths.manifest_map, "course")
     course_result, _ = run_onboard_gate_2_entity_with_grain_uc(
@@ -1104,6 +1140,7 @@ def run_onboard_gate_2(
         grain_hitl_path=paths.run_root / "course_sma_grain_hitl.json",
         poll_interval_seconds=DEFAULT_HITL_POLL_INTERVAL_SECONDS,
         timeout_seconds=DEFAULT_HITL_POLL_TIMEOUT_SECONDS,
+        hook_modules_root=paths.run_root,
     )
 
     # Step 2d — Pandera validation (report only, does not block)
@@ -1213,6 +1250,7 @@ def run_execute(
         manifest_map_path=paths.active_manifest_map,
         grain_hitl_path=paths.run_root / "cohort_sma_grain_hitl.json",
         active_grain_resolution_root=paths.active_root,
+        hook_modules_root=paths.active_root,
     )
     course_result = execute_transformation_map_for_sma_execute_mode(
         transformation_map=course_map,
@@ -1225,6 +1263,7 @@ def run_execute(
         manifest_map_path=paths.active_manifest_map,
         grain_hitl_path=paths.run_root / "course_sma_grain_hitl.json",
         active_grain_resolution_root=paths.active_root,
+        hook_modules_root=paths.active_root,
     )
 
     # Pandera validation (report only)

--- a/tests/genai/mapping/schema_mapping_agent/execution/test_hook_execution.py
+++ b/tests/genai/mapping/schema_mapping_agent/execution/test_hook_execution.py
@@ -33,11 +33,14 @@ from edvise.genai.mapping.schema_mapping_agent.transformation.schemas import (
     FieldTransformationPlan,
     TransformationMap,
 )
-from edvise.genai.mapping.shared.hitl.hook_spec.schemas import HookFunctionSpec, HookSpec
+from edvise.genai.mapping.shared.hitl.hook_spec.schemas import (
+    HookFunctionSpec,
+    HookSpec,
+)
 
 HOOK_MODULE_RELPATH = "transform_hooks.py"
 
-PREFIX_HOOK_DRAFT = '''def transform_course_course_prefix(s: "pd.Series") -> "pd.Series":
+PREFIX_HOOK_DRAFT = """def transform_course_course_prefix(s: "pd.Series") -> "pd.Series":
     import pandas as pd
     import re
 
@@ -48,7 +51,7 @@ PREFIX_HOOK_DRAFT = '''def transform_course_course_prefix(s: "pd.Series") -> "pd
         return match.group(1).upper() if match else None
 
     return s.apply(extract_alpha_prefix).astype("string")
-'''
+"""
 
 
 def _manifest(course_number_source: str = "course_number") -> FieldMappingManifest:
@@ -127,7 +130,9 @@ def test_hook_required_without_hook_spec_raises_on_gap(tmp_path: Path) -> None:
         target_schema="RawEdviseCourseDataSchema",
         plans=[
             FieldTransformationPlan(target_field="course_id", steps=[]),
-            FieldTransformationPlan(target_field="course_prefix", steps=[], hook_required=True),
+            FieldTransformationPlan(
+                target_field="course_prefix", steps=[], hook_required=True
+            ),
         ],
     )
     with pytest.raises(ExecutionGapError):
@@ -228,7 +233,9 @@ def test_hook_missing_on_disk_raises_execution_error(tmp_path: Path) -> None:
     """hook_spec points at a module that was never materialized — a real bug, not a soft gap."""
     hook_spec = HookSpec(
         file=HOOK_MODULE_RELPATH,
-        functions=[HookFunctionSpec(name="transform_course_course_prefix", description="x")],
+        functions=[
+            HookFunctionSpec(name="transform_course_course_prefix", description="x")
+        ],
     )
     tm = TransformationMap(
         institution_id="test_inst",
@@ -257,8 +264,7 @@ def test_hook_missing_on_disk_raises_execution_error(tmp_path: Path) -> None:
 
 def test_hook_returning_non_series_raises_execution_error(tmp_path: Path) -> None:
     bad_draft = (
-        'def transform_course_course_prefix(s: "pd.Series"):\n'
-        "    return list(s)\n"
+        'def transform_course_course_prefix(s: "pd.Series"):\n    return list(s)\n'
     )
     _materialize(tmp_path, bad_draft)
     hook_spec = HookSpec(

--- a/tests/genai/mapping/schema_mapping_agent/execution/test_hook_execution.py
+++ b/tests/genai/mapping/schema_mapping_agent/execution/test_hook_execution.py
@@ -1,0 +1,294 @@
+"""
+hook_required plans stay execution gaps until a materialized hook_spec is attached; once
+attached, execute_transformation_map dynamically imports the materialized module and runs the
+named function instead of skipping the field.
+
+Regression coverage for the gap identified in PR #155 (refactor: simplify and refine SMA
+transformation HITL): materialize_hook_specs_to_file wrote transform_hooks.py, but nothing ever
+attached the materialized function back onto its plan, and the executor had no loader for it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from edvise.data_audit.schemas.raw_edvise_course import RawEdviseCourseDataSchema
+from edvise.genai.mapping.schema_mapping_agent.execution.field_executor import (
+    ExecutionError,
+    execute_transformation_map,
+)
+from edvise.genai.mapping.schema_mapping_agent.execution.step_dispatcher import (
+    ExecutionGapError,
+)
+from edvise.genai.mapping.schema_mapping_agent.manifest.schemas import (
+    FieldMappingManifest,
+    FieldMappingRecord,
+    RowSelectionConfig,
+    RowSelectionStrategy,
+)
+from edvise.genai.mapping.schema_mapping_agent.transformation.schemas import (
+    FieldTransformationPlan,
+    TransformationMap,
+)
+from edvise.genai.mapping.shared.hitl.hook_spec.schemas import HookFunctionSpec, HookSpec
+
+HOOK_MODULE_RELPATH = "transform_hooks.py"
+
+PREFIX_HOOK_DRAFT = '''def transform_course_course_prefix(s: "pd.Series") -> "pd.Series":
+    import pandas as pd
+    import re
+
+    def extract_alpha_prefix(code):
+        if pd.isna(code) or code == "":
+            return None
+        match = re.match(r"^([A-Za-z]+)", str(code).strip())
+        return match.group(1).upper() if match else None
+
+    return s.apply(extract_alpha_prefix).astype("string")
+'''
+
+
+def _manifest(course_number_source: str = "course_number") -> FieldMappingManifest:
+    return FieldMappingManifest(
+        entity_type="course",
+        target_schema="RawEdviseCourseDataSchema",
+        mappings=[
+            FieldMappingRecord(
+                target_field="course_id",
+                source_column="course_id",
+                source_table="course",
+                row_selection=RowSelectionConfig(strategy=RowSelectionStrategy.any_row),
+                confidence=1.0,
+                rationale="",
+            ),
+            FieldMappingRecord(
+                target_field="course_prefix",
+                source_column=course_number_source,
+                source_table="course",
+                row_selection=RowSelectionConfig(strategy=RowSelectionStrategy.any_row),
+                confidence=0.6,
+                rationale="",
+            ),
+        ],
+        column_aliases=[],
+    )
+
+
+def _dataframes() -> dict[str, pd.DataFrame]:
+    return {
+        "course": pd.DataFrame(
+            {
+                "course_id": [1, 2, 3],
+                "course_number": ["ENC1101", "CGS1060C", "MAC1105"],
+            }
+        )
+    }
+
+
+def _materialize(tmp_path: Path, draft: str) -> None:
+    (tmp_path / HOOK_MODULE_RELPATH).write_text(draft, encoding="utf-8")
+
+
+def test_hook_required_without_hook_spec_is_still_a_gap(tmp_path: Path) -> None:
+    """Preserves prior behavior: hook_required alone (no materialized pointer) is a gap."""
+    tm = TransformationMap(
+        institution_id="test_inst",
+        entity_type="course",
+        target_schema="RawEdviseCourseDataSchema",
+        plans=[
+            FieldTransformationPlan(target_field="course_id", steps=[]),
+            FieldTransformationPlan(
+                target_field="course_prefix",
+                steps=[],
+                hook_required=True,
+                reviewer_notes="needs alpha/digit split",
+            ),
+        ],
+    )
+    out = execute_transformation_map(
+        tm,
+        _manifest(),
+        _dataframes(),
+        RawEdviseCourseDataSchema,
+        institution_id="test_inst",
+        hook_modules_root=tmp_path,
+    )
+    assert out.gaps == ["course_prefix"]
+    assert "course_prefix" not in out.df.columns
+
+
+def test_hook_required_without_hook_spec_raises_on_gap(tmp_path: Path) -> None:
+    tm = TransformationMap(
+        institution_id="test_inst",
+        entity_type="course",
+        target_schema="RawEdviseCourseDataSchema",
+        plans=[
+            FieldTransformationPlan(target_field="course_id", steps=[]),
+            FieldTransformationPlan(target_field="course_prefix", steps=[], hook_required=True),
+        ],
+    )
+    with pytest.raises(ExecutionGapError):
+        execute_transformation_map(
+            tm,
+            _manifest(),
+            _dataframes(),
+            RawEdviseCourseDataSchema,
+            institution_id="test_inst",
+            raise_on_gap=True,
+            hook_modules_root=tmp_path,
+        )
+
+
+def test_hook_required_with_attached_hook_spec_runs_materialized_function(
+    tmp_path: Path,
+) -> None:
+    """The exact ENC1101 -> ENC scenario: a materialized hook_spec makes the field executable."""
+    _materialize(tmp_path, PREFIX_HOOK_DRAFT)
+    hook_spec = HookSpec(
+        file=HOOK_MODULE_RELPATH,
+        functions=[
+            HookFunctionSpec(
+                name="transform_course_course_prefix",
+                description="Extract leading alpha prefix from a combined course code.",
+                draft=PREFIX_HOOK_DRAFT,
+            )
+        ],
+    )
+    tm = TransformationMap(
+        institution_id="test_inst",
+        entity_type="course",
+        target_schema="RawEdviseCourseDataSchema",
+        plans=[
+            FieldTransformationPlan(target_field="course_id", steps=[]),
+            FieldTransformationPlan(
+                target_field="course_prefix",
+                steps=[],
+                hook_required=True,
+                hook_spec=hook_spec,
+                reviewer_notes="needs alpha/digit split",
+            ),
+        ],
+    )
+    out = execute_transformation_map(
+        tm,
+        _manifest(),
+        _dataframes(),
+        RawEdviseCourseDataSchema,
+        institution_id="test_inst",
+        hook_modules_root=tmp_path,
+    )
+    assert out.gaps == []
+    assert "course_prefix" in out.executed
+    assert out.df["course_prefix"].tolist() == ["ENC", "CGS", "MAC"]
+
+
+def test_hook_required_missing_hook_modules_root_is_a_gap_even_with_hook_spec(
+    tmp_path: Path,
+) -> None:
+    """Without hook_modules_root, hook_spec is never consulted — same as omitting it."""
+    hook_spec = HookSpec(
+        file=HOOK_MODULE_RELPATH,
+        functions=[
+            HookFunctionSpec(
+                name="transform_course_course_prefix",
+                description="x",
+                draft=PREFIX_HOOK_DRAFT,
+            )
+        ],
+    )
+    tm = TransformationMap(
+        institution_id="test_inst",
+        entity_type="course",
+        target_schema="RawEdviseCourseDataSchema",
+        plans=[
+            FieldTransformationPlan(target_field="course_id", steps=[]),
+            FieldTransformationPlan(
+                target_field="course_prefix",
+                steps=[],
+                hook_required=True,
+                hook_spec=hook_spec,
+            ),
+        ],
+    )
+    out = execute_transformation_map(
+        tm,
+        _manifest(),
+        _dataframes(),
+        RawEdviseCourseDataSchema,
+        institution_id="test_inst",
+        # hook_modules_root omitted
+    )
+    assert out.gaps == ["course_prefix"]
+
+
+def test_hook_missing_on_disk_raises_execution_error(tmp_path: Path) -> None:
+    """hook_spec points at a module that was never materialized — a real bug, not a soft gap."""
+    hook_spec = HookSpec(
+        file=HOOK_MODULE_RELPATH,
+        functions=[HookFunctionSpec(name="transform_course_course_prefix", description="x")],
+    )
+    tm = TransformationMap(
+        institution_id="test_inst",
+        entity_type="course",
+        target_schema="RawEdviseCourseDataSchema",
+        plans=[
+            FieldTransformationPlan(target_field="course_id", steps=[]),
+            FieldTransformationPlan(
+                target_field="course_prefix",
+                steps=[],
+                hook_required=True,
+                hook_spec=hook_spec,
+            ),
+        ],
+    )
+    with pytest.raises(ExecutionError, match="not found"):
+        execute_transformation_map(
+            tm,
+            _manifest(),
+            _dataframes(),
+            RawEdviseCourseDataSchema,
+            institution_id="test_inst",
+            hook_modules_root=tmp_path,
+        )
+
+
+def test_hook_returning_non_series_raises_execution_error(tmp_path: Path) -> None:
+    bad_draft = (
+        'def transform_course_course_prefix(s: "pd.Series"):\n'
+        "    return list(s)\n"
+    )
+    _materialize(tmp_path, bad_draft)
+    hook_spec = HookSpec(
+        file=HOOK_MODULE_RELPATH,
+        functions=[
+            HookFunctionSpec(
+                name="transform_course_course_prefix", description="x", draft=bad_draft
+            )
+        ],
+    )
+    tm = TransformationMap(
+        institution_id="test_inst",
+        entity_type="course",
+        target_schema="RawEdviseCourseDataSchema",
+        plans=[
+            FieldTransformationPlan(target_field="course_id", steps=[]),
+            FieldTransformationPlan(
+                target_field="course_prefix",
+                steps=[],
+                hook_required=True,
+                hook_spec=hook_spec,
+            ),
+        ],
+    )
+    with pytest.raises(ExecutionError, match="must return a pandas Series"):
+        execute_transformation_map(
+            tm,
+            _manifest(),
+            _dataframes(),
+            RawEdviseCourseDataSchema,
+            institution_id="test_inst",
+            hook_modules_root=tmp_path,
+        )

--- a/tests/genai/mapping/schema_mapping_agent/test_transformation_hook_hitl.py
+++ b/tests/genai/mapping/schema_mapping_agent/test_transformation_hook_hitl.py
@@ -10,6 +10,7 @@ import pytest
 from edvise.genai.mapping.schema_mapping_agent.transformation.hitl.hook_required_hitl import (
     InstitutionSMATransformationHookHITLItems,
     apply_transformation_hook_hitl_resolutions,
+    attach_materialized_hook_specs_to_plans,
     build_transformation_hook_hitl_envelope_for_entity,
     check_transformation_hook_hitl_gate,
     write_transformation_hook_hitl_envelope,
@@ -117,3 +118,68 @@ def test_check_gate_blocks_pending(tmp_path: Path):
 
     with pytest.raises(HITLBlockingError):
         check_transformation_hook_hitl_gate(path)
+
+
+def _hook_preview_row(*, target_field: str, entity_type: str) -> dict:
+    return {
+        "item_id": f"u_test_{entity_type}_{target_field}_hook_required",
+        "hook_spec": {
+            "file": "transform_hooks.py",
+            "functions": [
+                {
+                    "name": f"transform_{entity_type}_{target_field}",
+                    "description": "generated",
+                    "draft": f'def transform_{entity_type}_{target_field}(s):\n    return s\n',
+                }
+            ],
+        },
+        "review_context": {"entity_type": entity_type, "target_field": target_field},
+    }
+
+
+def test_attach_materialized_hook_specs_sets_hook_spec_on_matching_plan():
+    """Closes the gap PR #155 introduced: materialize wrote transform_hooks.py, but nothing
+    ever pointed the plan at it, so hook_required plans stayed unresolved gaps forever."""
+    data = _sample_wrapper(hook_on_x=True)
+    rows = [_hook_preview_row(target_field="x", entity_type="cohort")]
+    out = attach_materialized_hook_specs_to_plans(
+        data, entity_type="cohort", preview_rows=rows
+    )
+    plan = out["transformation_maps"]["cohort"]["plans"][0]
+    assert plan["target_field"] == "x"
+    # hook_required stays true — it still means "no built-in utility chain covers this"
+    assert plan["hook_required"] is True
+    assert plan["hook_spec"]["file"] == "transform_hooks.py"
+    assert plan["hook_spec"]["functions"][0]["name"] == "transform_cohort_x"
+    # original dict is untouched
+    assert "hook_spec" not in data["transformation_maps"]["cohort"]["plans"][0]
+
+
+def test_attach_materialized_hook_specs_ignores_wrong_entity_type():
+    data = _sample_wrapper(hook_on_x=True)
+    rows = [_hook_preview_row(target_field="x", entity_type="course")]
+    out = attach_materialized_hook_specs_to_plans(
+        data, entity_type="cohort", preview_rows=rows
+    )
+    plan = out["transformation_maps"]["cohort"]["plans"][0]
+    assert "hook_spec" not in plan
+
+
+def test_attach_materialized_hook_specs_ignores_non_hook_required_plan():
+    data = _sample_wrapper(hook_on_x=False)
+    rows = [_hook_preview_row(target_field="x", entity_type="cohort")]
+    out = attach_materialized_hook_specs_to_plans(
+        data, entity_type="cohort", preview_rows=rows
+    )
+    plan = out["transformation_maps"]["cohort"]["plans"][0]
+    assert "hook_spec" not in plan
+
+
+def test_attach_materialized_hook_specs_ignores_unknown_target_field():
+    data = _sample_wrapper(hook_on_x=True)
+    rows = [_hook_preview_row(target_field="does_not_exist", entity_type="cohort")]
+    out = attach_materialized_hook_specs_to_plans(
+        data, entity_type="cohort", preview_rows=rows
+    )
+    plan = out["transformation_maps"]["cohort"]["plans"][0]
+    assert "hook_spec" not in plan

--- a/tests/genai/mapping/schema_mapping_agent/test_transformation_hook_hitl.py
+++ b/tests/genai/mapping/schema_mapping_agent/test_transformation_hook_hitl.py
@@ -129,7 +129,7 @@ def _hook_preview_row(*, target_field: str, entity_type: str) -> dict:
                 {
                     "name": f"transform_{entity_type}_{target_field}",
                     "description": "generated",
-                    "draft": f'def transform_{entity_type}_{target_field}(s):\n    return s\n',
+                    "draft": f"def transform_{entity_type}_{target_field}(s):\n    return s\n",
                 }
             ],
         },


### PR DESCRIPTION
## Summary
- `hook_required` plans were silently unexecutable: `materialize_hook_specs_to_file` wrote the generated function to `transform_hooks.py`, but nothing ever pointed the plan at it and the field executor had no loader for it — a regression made worse by #155, which removed the only gate that could clear `hook_required`.
- Adds `FieldTransformationPlan.hook_spec` (mirrors IdentityAgent's self-describing `hook_spec` pattern on `DedupPolicy`/`TermContract`) and `attach_materialized_hook_specs_to_plans`, called right after materialization in `edvise_genai_sma.py`, to patch each `hook_required` plan with its materialized function's file/name.
- Adds a dynamic-import loader in `field_executor.py` (`_load_sma_transform_hook_function`, mirroring `identity_agent/execution/contract_utilities.py`'s pattern) so `execute_transformation_map` calls the generated `Series -> Series` function instead of treating the field as a gap, when `hook_spec` + `hook_modules_root` are present. Behavior is unchanged when either is absent.
- Threads `hook_modules_root` through `execute_transformation_map`, `execute_transformation_map_for_sma_run`, and `run_onboard_gate_2_entity_with_grain_uc` (`paths.run_root` for onboard, `paths.active_root` for execute mode, matching how `transform_hooks.py` is materialized/promoted).

## Asana
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216920327381741?focus=true

## Test plan
- [x] `uv run pytest tests/genai/mapping/schema_mapping_agent/ -q` — 148 passed (includes new `tests/.../execution/test_hook_execution.py`, which reproduces the exact `ENC1101 -> ENC` / `CGS1060C -> CGS` scenario end-to-end through `execute_transformation_map`, plus regression coverage for the prior gap-only behavior, missing-module errors, and non-Series return values).
- [x] `uv run pytest tests/genai/mapping/schema_mapping_agent/test_transformation_hook_hitl.py -q` — covers `attach_materialized_hook_specs_to_plans` matching/filtering behavior.

Made with [Cursor](https://cursor.com)