### PR TITLE
fix: pin CI service principal CAN_MANAGE on GenAI HITL app permissions

### DIFF
--- a/.github/workflows/deploy-genai-hitl-app.yml
+++ b/.github/workflows/deploy-genai-hitl-app.yml
@@ -66,11 +66,13 @@ jobs:
             --target=dev \
             --force-lock \
             --var="sql_warehouse_id=$SQL_WAREHOUSE_ID" \
-            --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE"
+            --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE" \
+            --var="ci_service_principal_id=$DATABRICKS_CLIENT_ID"
           databricks bundle run genai_hitl \
             --target=dev \
             --var="sql_warehouse_id=$SQL_WAREHOUSE_ID" \
-            --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE"
+            --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE" \
+            --var="ci_service_principal_id=$DATABRICKS_CLIENT_ID"
 
   deploy-staging:
     name: Deploy GenAI HITL app to staging (staging_sst_01)
@@ -122,8 +124,10 @@ jobs:
             --target=prod \
             --force-lock \
             --var="sql_warehouse_id=$SQL_WAREHOUSE_ID" \
-            --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE"
+            --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE" \
+            --var="ci_service_principal_id=$DATABRICKS_CLIENT_ID"
           databricks bundle run genai_hitl \
             --target=prod \
             --var="sql_warehouse_id=$SQL_WAREHOUSE_ID" \
-            --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE"
+            --var="datakind_group_to_manage_workflow=$GROUP_TO_MANAGE" \
+            --var="ci_service_principal_id=$DATABRICKS_CLIENT_ID"

--- a/src/edvise/genai/mapping/streamlit-genai-hitl-app/databricks.yml
+++ b/src/edvise/genai/mapping/streamlit-genai-hitl-app/databricks.yml
@@ -1,6 +1,14 @@
 # Databricks Apps bundle — GenAI HITL reviewer (UC hitl_reviews).
 # Deploy: databricks bundle deploy --target dev
 # Requires variables: sql_warehouse_id, datakind_group_to_manage_workflow (see metadata app pattern).
+#
+# ci_service_principal_id must be set to the application ID of whichever identity CI deploys as for
+# the target (DATABRICKS_GENAI_MAPPING_DEV_CLIENT_ID / _STAGING_CLIENT_ID secret). This is required
+# on every deploy, including local ones, so that a one-off `bundle deploy` from your laptop (which
+# runs as your personal user) doesn't reset the app's permission rule set to only what's declared
+# here — which would drop the CI service principal's CAN_MANAGE and break the next CI-driven release
+# deploy with a `does not have apps.ruleSets/get` error. When deploying locally, pass
+# --var="ci_service_principal_id=<the dev/staging client id>" same as CI does.
 
 bundle:
   name: edvise_genai_hitl_app
@@ -23,6 +31,8 @@ variables:
     description: Group with permissions to manage the app
   genai_catalog:
     description: UC catalog containing genai_mapping.hitl_reviews
+  ci_service_principal_id:
+    description: Application ID of the CI service principal that deploys this bundle for the target
 
 targets:
   dev:
@@ -74,6 +84,8 @@ resources:
             value: "false"
       permissions:
         - group_name: ${var.datakind_group_to_manage_workflow}
+          level: CAN_MANAGE
+        - service_principal_name: ${var.ci_service_principal_id}
           level: CAN_MANAGE
         - group_name: users
           level: CAN_USE


### PR DESCRIPTION
## Summary
- The v1.6.0 `Release Deploy` run failed deploying the GenAI HITL app to dev with `does not have apps.ruleSets/get`, because the CI service principal's `CAN_MANAGE` grant on the `edvise-genai-hitl-dev` app had been dropped between v1.5.3 and v1.6.0.
- Root cause: the app's `permissions` block only listed a group and `users`, so CI's `CAN_MANAGE` was only ever implicit (as original creator/owner). A local `bundle deploy` against the `dev` target (the default target, easy to do while iterating on the app locally, e.g. the Manifest Explorer work) runs as the deploying human's identity and reconciles the app's permission rule set down to exactly what's declared in `databricks.yml`, silently dropping CI's access.
- Fix: make the CI service principal's `CAN_MANAGE` grant explicit and declarative via a new required `ci_service_principal_id` bundle variable, sourced from the same `DATABRICKS_CLIENT_ID` already used for OAuth auth in `deploy-genai-hitl-app.yml` (dev and staging). Any deploy — CI or local — now re-affirms CI's access instead of relying on implicit ownership.

## Test plan
- [ ] CI (`style`/`type-check`/`test`) passes on this PR.
- [ ] After merge, manually restore `CAN_MANAGE` for the CI service principal on `edvise-genai-hitl-dev` in `dev_sst_02` (one-time fix for the currently broken app), since this PR only prevents recurrence going forward.
- [ ] Re-run `deploy-genai-hitl-app.yml` (`workflow_dispatch`) against `v1.6.0` or the next release to confirm the dev deploy succeeds and the permissions reconciliation includes the service principal without error.

Made with [Cursor](https://cursor.com)