### PR TITLE
fix: make DK_CC_EMAIL optional for inference/training kickoff emails

### DIFF
--- a/pipelines/es/resources/github_es_inference.yml
+++ b/pipelines/es/resources/github_es_inference.yml
@@ -400,7 +400,7 @@ resources:
         - name: DB_workspace
           default: ${var.DB_workspace}
         - name: DK_CC_EMAIL
-          default: ${var.datakind_notification_email}
+          default: ""
         - name: config_file_name
           default: ${var.config_file_name}
         - name: ds_run_as

--- a/pipelines/es/resources/github_es_training.yml
+++ b/pipelines/es/resources/github_es_training.yml
@@ -335,7 +335,7 @@ resources:
         - name: DB_workspace
           default: ${var.DB_workspace}
         - name: DK_CC_EMAIL
-          default: ${var.datakind_notification_email}
+          default: ""
         - name: config_file_name
           default: ${var.config_file_name}
         - name: ds_run_as

--- a/pipelines/legacy/resources/github_legacy_inference.yml
+++ b/pipelines/legacy/resources/github_legacy_inference.yml
@@ -249,7 +249,7 @@ resources:
         - name: datakind_notification_email
           default: ${var.datakind_notification_email}
         - name: DK_CC_EMAIL
-          default: ${var.datakind_notification_email}
+          default: ""
         - name: term_filter
           default: ""
       permissions:

--- a/pipelines/legacy/resources/github_legacy_training.yml
+++ b/pipelines/legacy/resources/github_legacy_training.yml
@@ -206,7 +206,7 @@ resources:
         - name: DB_workspace
           default: ${var.DB_workspace}
         - name: DK_CC_EMAIL
-          default: ${var.datakind_notification_email}
+          default: ""
         - name: config_file_name
           default: ${var.config_file_name}
         - name: features_table_name

--- a/pipelines/pdp/resources/github_pdp_inference.yml
+++ b/pipelines/pdp/resources/github_pdp_inference.yml
@@ -337,7 +337,7 @@ resources:
         - name: DB_workspace
           default: ${var.DB_workspace}
         - name: DK_CC_EMAIL
-          default: ${var.datakind_notification_email}
+          default: ""
         - name: config_file_name
           default: ${var.config_file_name}
         - name: ds_run_as

--- a/pipelines/pdp/resources/github_pdp_training.yml
+++ b/pipelines/pdp/resources/github_pdp_training.yml
@@ -333,7 +333,7 @@ resources:
         - name: DB_workspace
           default: ${var.DB_workspace}
         - name: DK_CC_EMAIL
-          default: ${var.datakind_notification_email}
+          default: ""
         - name: config_file_name
           default: ${var.config_file_name}
         - name: ds_run_as

--- a/src/edvise/scripts/inference_h2o.py
+++ b/src/edvise/scripts/inference_h2o.py
@@ -482,10 +482,11 @@ class ModelInferenceTask:
         MANDRILL_PASSWORD = w.dbutils.secrets.get(scope="sst", key="MANDRILL_PASSWORD")
         SENDER_EMAIL = Address("Datakind Info", "help", "datakind.org")
 
+        cc_email_list = [self.args.DK_CC_EMAIL] if self.args.DK_CC_EMAIL else []
         emails.send_inference_kickoff_email(
             str(SENDER_EMAIL),
             [self.args.datakind_notification_email],
-            [self.args.DK_CC_EMAIL],
+            cc_email_list,
             MANDRILL_USERNAME,
             MANDRILL_PASSWORD,
         )
@@ -522,7 +523,13 @@ def parse_arguments() -> argparse.Namespace:
     )
     parser.add_argument("--silver_volume_path", type=str, required=True)
     parser.add_argument("--datakind_notification_email", type=str, required=True)
-    parser.add_argument("--DK_CC_EMAIL", type=str, required=True)
+    parser.add_argument(
+        "--DK_CC_EMAIL",
+        type=str,
+        required=False,
+        default="",
+        help="Optional CC address for the inference kickoff email.",
+    )
     parser.add_argument("--features_table_path", type=str, required=False)
     parser.add_argument("--ds_run_as", type=str, required=False)
     parser.add_argument(


### PR DESCRIPTION
## Summary
- `DK_CC_EMAIL` was declared with a default of `${var.datakind_notification_email}` across the PDP/ES/legacy training and inference job YAMLs. That resolves to an empty string and is treated as a "non-concrete" default by the versioned inference launcher's parameter-contract resolver (`pipelines/pdp/launchers/inference_parameters.py`), so it was silently promoted to a **required** parameter for any task that references it (`inference_h2o`).
- This caused `edvise_versioned_inference_launcher` to fail closed (`Parameter contract validation failed: ... missing required parameter value(s): 'DK_CC_EMAIL'`) whenever a caller didn't explicitly pass a CC address — which is the common case, since CC is inherently optional.
- Fix: make `DK_CC_EMAIL` genuinely optional end-to-end.
  - `inference_h2o.py`: `--DK_CC_EMAIL` is no longer `required=True`; defaults to `""`, and the kickoff email now sends with an empty CC list instead of `[""]` when unset.
  - `github_pdp_inference.yml`, `github_pdp_training.yml`, `github_es_inference.yml`, `github_es_training.yml`, `github_legacy_training.yml`, `github_legacy_inference.yml`: `DK_CC_EMAIL`'s job-parameter default changed to a literal `default: ""`, matching how `cohort_file_name`/`course_file_name`/`gcp_bucket_name` are already treated as optional.
- `datakind_notification_email` (the primary recipient) is untouched and remains required everywhere.

## Note on scope
This fixes the failure for **future** `pipeline_version` releases (new archived bundles cut after this merges). It does not retroactively affect already-archived releases already sitting in `edvise_releases` volumes, since those are immutable snapshots of the repo at release time.

## Test plan
- [x] `uv run python -m pytest tests/pdp -q` — 77 passed, 1 skipped
- [x] `uv tool run ruff check src/edvise/scripts/inference_h2o.py` — clean
- [x] `uv tool run ruff format --diff src/edvise/scripts/inference_h2o.py` — already formatted
- [x] `uv run python -m mypy --install-types --non-interactive src/edvise/scripts/inference_h2o.py` — no issues
- [ ] Confirm `send_inference_kickoff_email` renders correctly with an empty CC list in a real Databricks run

Made with [Cursor](https://cursor.com)