### PR TITLE
fix(genai): flag exact-duplicate SMA Pass 2 TERMINAL HITL options

### DIFF
--- a/src/edvise/genai/mapping/schema_mapping_agent/manifest/hitl/option_validation.py
+++ b/src/edvise/genai/mapping/schema_mapping_agent/manifest/hitl/option_validation.py
@@ -14,6 +14,12 @@ block Pass 2 retries with no way to fix them via Pass 2 output (which only carri
 
 Used inside Pass 2 ``llm_complete_with_parse_retry`` so invalid options trigger a
 retry with structured errors in the correction hint.
+
+Also includes :func:`raise_if_pass2_terminal_options_not_distinct`, a separate
+deterministic check that flags exact-duplicate TERMINAL options within the same
+item (identical sourcing once provenance/confidence metadata is stripped) and
+raises through the same retry path. Near-identical-but-not-exact options are
+intentionally not flagged yet.
 """
 
 from __future__ import annotations
@@ -29,7 +35,7 @@ from edvise.genai.mapping.shared.schema_contract.schemas import (
     EnrichedSchemaContractForSMA,
 )
 
-from ..schemas import FieldMappingManifest
+from ..schemas import ColumnAlias, FieldMappingManifest, FieldMappingRecord
 from ..validation import ManifestValidationError, validate_manifest
 from .schemas import SMAHITLItem, SMAHITLOption, SMAReentryDepth, add_alias_if_missing
 
@@ -130,6 +136,130 @@ def collect_pass2_terminal_option_validation_failures(
     return failures
 
 
+_FIELD_MAPPING_METADATA_KEYS = frozenset(
+    {
+        "confidence",
+        "rationale",
+        "validation_notes",
+        "review_status",
+        "reviewer_notes",
+        "corrected_source_column",
+    }
+)
+"""Keys excluded when fingerprinting a FieldMappingRecord for distinctness.
+
+These describe provenance/confidence, not sourcing behavior — two options that
+differ only in these fields resolve to the same executed value.
+"""
+
+
+def _field_mapping_fingerprint(field_mapping: FieldMappingRecord) -> tuple:
+    """Structural fingerprint of a FieldMappingRecord, ignoring metadata fields."""
+    dumped = field_mapping.model_dump(mode="json")
+    for key in _FIELD_MAPPING_METADATA_KEYS:
+        dumped.pop(key, None)
+    return tuple(sorted(dumped.items()))
+
+
+def _column_alias_fingerprint(column_alias: ColumnAlias | None) -> tuple | None:
+    if column_alias is None:
+        return None
+    return (
+        column_alias.table,
+        column_alias.source_column,
+        column_alias.canonical_column,
+    )
+
+
+def find_duplicate_terminal_options(
+    item: SMAHITLItem,
+) -> list[tuple[str, str]]:
+    """
+    Pairs of TERMINAL ``option_id``\\ s in ``item`` with identical sourcing
+    fingerprints (``field_mapping`` minus provenance/confidence metadata, plus
+    ``column_alias``).
+
+    Only exact duplicates are flagged — two options that differ in any
+    sourcing-relevant field (``source_column``, ``source_table``, ``join``,
+    ``row_selection``) are left alone, even if very similar.
+    """
+    terminal = [opt for opt in item.options if opt.reentry == SMAReentryDepth.TERMINAL]
+    dupes: list[tuple[str, str]] = []
+    for i in range(len(terminal)):
+        for j in range(i + 1, len(terminal)):
+            a, b = terminal[i], terminal[j]
+            assert a.field_mapping is not None and b.field_mapping is not None
+            if _field_mapping_fingerprint(
+                a.field_mapping
+            ) == _field_mapping_fingerprint(
+                b.field_mapping
+            ) and _column_alias_fingerprint(
+                a.column_alias
+            ) == _column_alias_fingerprint(b.column_alias):
+                dupes.append((a.option_id, b.option_id))
+    return dupes
+
+
+def collect_pass2_duplicate_terminal_options(
+    items: list[SMAHITLItem],
+) -> list[tuple[str, str, str]]:
+    """
+    Find exact-duplicate TERMINAL options across all Pass 2 ``items``.
+
+    Returns:
+        List of ``(item_id, option_id_a, option_id_b)`` tuples, one per
+        duplicate pair found within an item.
+    """
+    failures: list[tuple[str, str, str]] = []
+    for item in items:
+        for opt_a, opt_b in find_duplicate_terminal_options(item):
+            failures.append((item.item_id, opt_a, opt_b))
+    return failures
+
+
+def raise_if_pass2_terminal_options_not_distinct(
+    items: list[SMAHITLItem],
+) -> None:
+    """
+    Raise :class:`pydantic.ValidationError` if any item has two TERMINAL
+    options with identical sourcing (``field_mapping`` sans metadata, plus
+    ``column_alias``) — the reviewer would be choosing between two options
+    that resolve to the same value (for ``llm_complete_with_parse_retry``).
+
+    Only exact duplicates are flagged; near-identical-but-distinct options
+    are intentionally left alone for now.
+    """
+    failures = collect_pass2_duplicate_terminal_options(items)
+    if not failures:
+        return
+
+    lines: list[str] = [
+        "Two or more TERMINAL HITL options within the same item are exact "
+        "duplicates (identical source_column, source_table, join, row_selection, "
+        "and column_alias). Each TERMINAL option must represent a distinct "
+        "resolution — remove or replace the duplicate so the reviewer isn't "
+        "choosing between two options that resolve identically.",
+        "",
+    ]
+    for item_id, opt_a, opt_b in failures:
+        lines.append(
+            f"- item_id={item_id} options {opt_a!r} and {opt_b!r} are duplicates"
+        )
+
+    msg = "\n".join(lines)
+    raise ValidationError.from_exception_data(
+        "SMAPass2TerminalOptionDistinctness",
+        [
+            {
+                "type": "value_error",
+                "loc": ("items",),
+                "input": None,
+                "ctx": {"error": ValueError(msg)},
+            }
+        ],
+    )
+
+
 def raise_if_pass2_terminal_options_invalid(
     refined_manifest: FieldMappingManifest,
     items: list[SMAHITLItem],
@@ -177,7 +307,10 @@ def raise_if_pass2_terminal_options_invalid(
 
 __all__ = [
     "build_scratch_manifest_for_terminal_option",
+    "collect_pass2_duplicate_terminal_options",
     "collect_pass2_terminal_option_validation_failures",
+    "find_duplicate_terminal_options",
     "raise_if_pass2_terminal_options_invalid",
+    "raise_if_pass2_terminal_options_not_distinct",
     "validate_terminal_hitl_option",
 ]

--- a/src/edvise/genai/mapping/schema_mapping_agent/manifest/prompts/refine.py
+++ b/src/edvise/genai/mapping/schema_mapping_agent/manifest/prompts/refine.py
@@ -8,7 +8,8 @@ SMA refinement + HITL: prompts, orchestration, and post-parse safety nets (singl
 **Pass 2** — option generation: one LLM call per entity with all Pass 1 flags for
 that entity in a single ``items`` array (cohort + course = 2 Pass 2 calls per institution;
 4 gateway calls total per institution). Each TERMINAL option is checked with the same
-deterministic ``validate_manifest`` pass as post–Step 2a generate (scratch manifest);
+deterministic ``validate_manifest`` pass as post–Step 2a generate (scratch manifest),
+and all TERMINAL options within an item are checked for exact-duplicate sourcing;
 failures trigger :func:`~edvise.utils.llm_utils.llm_complete_with_parse_retry`.
 
 Also includes :func:`run_sma_refinement` (two-pass LLM calls) and
@@ -1182,6 +1183,7 @@ def _run_pass2_llm_call(
 ) -> dict[str, Any]:
     from edvise.genai.mapping.schema_mapping_agent.manifest.hitl.option_validation import (
         raise_if_pass2_terminal_options_invalid,
+        raise_if_pass2_terminal_options_not_distinct,
     )
     from edvise.genai.mapping.schema_mapping_agent.manifest.hitl.schemas import (
         SMAHITLItem,
@@ -1233,6 +1235,7 @@ def _run_pass2_llm_call(
         raise_if_pass2_terminal_options_invalid(
             refined_manifest, hitl_items, schema_contract
         )
+        raise_if_pass2_terminal_options_not_distinct(hitl_items)
         data["items"] = [i.model_dump(mode="json") for i in hitl_items]
         return data
 

--- a/tests/unit/test_hitl_option_validation.py
+++ b/tests/unit/test_hitl_option_validation.py
@@ -7,8 +7,11 @@ from pydantic import ValidationError
 
 from edvise.genai.mapping.schema_mapping_agent.manifest.hitl.option_validation import (
     build_scratch_manifest_for_terminal_option,
+    collect_pass2_duplicate_terminal_options,
     collect_pass2_terminal_option_validation_failures,
+    find_duplicate_terminal_options,
     raise_if_pass2_terminal_options_invalid,
+    raise_if_pass2_terminal_options_not_distinct,
 )
 from edvise.genai.mapping.schema_mapping_agent.manifest.hitl.schemas import (
     SMAFailureMode,
@@ -437,3 +440,186 @@ def test_raise_if_pass2_terminal_options_invalid_raises():
     )
     with pytest.raises(ValidationError, match="item_id="):
         raise_if_pass2_terminal_options_invalid(refined, [item], contract)
+
+
+def _terminal_opt(
+    option_id: str,
+    field_mapping: FieldMappingRecord,
+    column_alias: ColumnAlias | None = None,
+) -> SMAHITLOption:
+    return SMAHITLOption(
+        option_id=option_id,
+        label=option_id,
+        description="d",
+        reentry=SMAReentryDepth.TERMINAL,
+        field_mapping=field_mapping,
+        column_alias=column_alias,
+    )
+
+
+def _direct_edit_opt() -> SMAHITLOption:
+    return SMAHITLOption(
+        option_id="direct_edit",
+        label="Edit",
+        description="E",
+        reentry=SMAReentryDepth.DIRECT_EDIT,
+        field_mapping=None,
+        column_alias=None,
+    )
+
+
+def _item_with_options(options: list[SMAHITLOption]) -> SMAHITLItem:
+    refined = _minimal_cohort_manifest()
+    return SMAHITLItem(
+        item_id="x_cohort_intended_program_type_low_confidence",
+        institution_id="x",
+        entity_type="cohort",
+        target_field="intended_program_type",
+        failure_mode=SMAFailureMode.LOW_CONFIDENCE,
+        hitl_question="q",
+        hitl_context=None,
+        current_field_mapping=refined.mappings[1],
+        validation_errors=[],
+        options=[*options, _direct_edit_opt()],
+    )
+
+
+def test_find_duplicate_terminal_options_flags_exact_duplicate():
+    """Two TERMINAL options differing only in confidence/rationale are still duplicates."""
+    fm_a = FieldMappingRecord(
+        target_field="intended_program_type",
+        source_column="active_degree",
+        source_table="student",
+        join=None,
+        row_selection=RowSelectionConfig(strategy=RowSelectionStrategy.any_row),
+        confidence=0.8,
+        rationale="model reasoning A",
+    )
+    fm_b = fm_a.model_copy(
+        update={"confidence": 0.6, "rationale": "different reasoning text"}
+    )
+    item = _item_with_options(
+        [_terminal_opt("opt_a", fm_a), _terminal_opt("opt_b", fm_b)]
+    )
+    dupes = find_duplicate_terminal_options(item)
+    assert dupes == [("opt_a", "opt_b")]
+
+
+def test_find_duplicate_terminal_options_ignores_distinct_sourcing():
+    fm_a = FieldMappingRecord(
+        target_field="intended_program_type",
+        source_column="active_degree",
+        source_table="student",
+        join=None,
+        row_selection=RowSelectionConfig(strategy=RowSelectionStrategy.any_row),
+        confidence=0.8,
+        rationale="",
+    )
+    fm_b = FieldMappingRecord(
+        target_field="intended_program_type",
+        source_column="declared_degree",
+        source_table="term",
+        join=JoinConfig(
+            base_table="student",
+            lookup_table="term",
+            join_keys=["learner_id", "term"],
+        ),
+        row_selection=RowSelectionConfig(
+            strategy=RowSelectionStrategy.where_not_null,
+            condition_col="declared_degree",
+        ),
+        confidence=0.7,
+        rationale="",
+    )
+    item = _item_with_options(
+        [_terminal_opt("opt_a", fm_a), _terminal_opt("opt_b", fm_b)]
+    )
+    assert find_duplicate_terminal_options(item) == []
+
+
+def test_find_duplicate_terminal_options_distinguishes_by_column_alias():
+    """Identical field_mapping but different column_alias is not (yet) a duplicate."""
+    fm = FieldMappingRecord(
+        target_field="intended_program_type",
+        source_column="declared_degree",
+        source_table="term",
+        join=JoinConfig(
+            base_table="student",
+            lookup_table="term",
+            join_keys=["learner_id", "term"],
+        ),
+        row_selection=RowSelectionConfig(strategy=RowSelectionStrategy.any_row),
+        confidence=0.7,
+        rationale="",
+    )
+    alias_a = ColumnAlias(
+        table="student", source_column="cohort_term", canonical_column="term"
+    )
+    alias_b = ColumnAlias(
+        table="student", source_column="starting_term", canonical_column="term"
+    )
+    item = _item_with_options(
+        [
+            _terminal_opt("opt_a", fm, alias_a),
+            _terminal_opt("opt_b", fm.model_copy(), alias_b),
+        ]
+    )
+    assert find_duplicate_terminal_options(item) == []
+
+
+def test_collect_pass2_duplicate_terminal_options_across_items():
+    fm = FieldMappingRecord(
+        target_field="intended_program_type",
+        source_column="active_degree",
+        source_table="student",
+        join=None,
+        row_selection=RowSelectionConfig(strategy=RowSelectionStrategy.any_row),
+        confidence=0.8,
+        rationale="",
+    )
+    dup_item = _item_with_options(
+        [
+            _terminal_opt("opt_a", fm.model_copy()),
+            _terminal_opt("opt_b", fm.model_copy(update={"confidence": 0.5})),
+        ]
+    )
+    clean_item = _item_with_options([_terminal_opt("only_opt", fm.model_copy())])
+    failures = collect_pass2_duplicate_terminal_options([dup_item, clean_item])
+    assert failures == [(dup_item.item_id, "opt_a", "opt_b")]
+
+
+def test_raise_if_pass2_terminal_options_not_distinct_raises():
+    fm = FieldMappingRecord(
+        target_field="intended_program_type",
+        source_column="active_degree",
+        source_table="student",
+        join=None,
+        row_selection=RowSelectionConfig(strategy=RowSelectionStrategy.any_row),
+        confidence=0.8,
+        rationale="",
+    )
+    item = _item_with_options(
+        [
+            _terminal_opt("opt_a", fm.model_copy()),
+            _terminal_opt("opt_b", fm.model_copy(update={"confidence": 0.5})),
+        ]
+    )
+    with pytest.raises(ValidationError, match="duplicates"):
+        raise_if_pass2_terminal_options_not_distinct([item])
+
+
+def test_raise_if_pass2_terminal_options_not_distinct_passes_when_distinct():
+    fm_a = FieldMappingRecord(
+        target_field="intended_program_type",
+        source_column="active_degree",
+        source_table="student",
+        join=None,
+        row_selection=RowSelectionConfig(strategy=RowSelectionStrategy.any_row),
+        confidence=0.8,
+        rationale="",
+    )
+    fm_b = fm_a.model_copy(update={"source_column": "other_degree_col"})
+    item = _item_with_options(
+        [_terminal_opt("opt_a", fm_a), _terminal_opt("opt_b", fm_b)]
+    )
+    raise_if_pass2_terminal_options_not_distinct([item])  # no raise


### PR DESCRIPTION
## Summary
- Adds a deterministic distinctness check for SMA Step 2a Pass 2 HITL option generation: flags when two `TERMINAL` options within the same `SMAHITLItem` have identical sourcing (`source_column`, `source_table`, `join`, `row_selection`, `column_alias`) once provenance/confidence metadata (`confidence`, `rationale`, `validation_notes`, `review_status`, `reviewer_notes`, `corrected_source_column`) is stripped out.
- Mirrors the existing `raise_if_pass2_terminal_options_invalid` pattern: raises a `pydantic.ValidationError` that feeds into the existing `llm_complete_with_parse_retry` retry path (`_parse_pass2_with_terminal_validation` in `refine.py`) rather than adding a new standalone validation pass.
- Scoped to exact duplicates only for now — near-identical-but-not-exact options (e.g. same `source_table`/`source_column` with different `row_selection`) are intentionally left unflagged pending further discussion.

## Asana
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216966527824491?focus=true

## Test plan
- [x] `uv run python -m pytest tests/unit/test_hitl_option_validation.py -q` — 10 passed (6 new cases covering exact duplicates despite differing metadata, distinct sourcing left alone, `column_alias`-only differences left alone, cross-item aggregation, and raise/pass behavior)
- [x] `uv tool run ruff check` / `ruff format --diff` on changed files
- [x] `uv run python -m mypy` on changed source files

Made with [Cursor](https://cursor.com)