### PR TITLE
fix(legacy): avoid advisor-output table collision for legacy multi-model institutions

### DIFF
--- a/src/edvise/scripts/training_h2o.py
+++ b/src/edvise/scripts/training_h2o.py
@@ -582,9 +582,12 @@ class TrainingTask:
         table). Falls back to the legacy hardcoded path for schools that don't configure it.
         """
         if self.spec.schema_type == "legacy":
-            gold_datasets = getattr(self.cfg.datasets, "gold", None) or {}
+            legacy_cfg = t.cast(configs.legacy.LegacyProjectConfig, self.cfg)
+            gold_datasets = legacy_cfg.datasets.gold or {}
             advisor_cfg = gold_datasets.get("advisor_output")
-            configured_path = getattr(advisor_cfg, "train_table_path", None) if advisor_cfg else None
+            configured_path: str | None = (
+                advisor_cfg.train_table_path if advisor_cfg else None
+            )
             if configured_path:
                 return configured_path
         return f"{self.args.gold_table_path}.advisor_output"

--- a/src/edvise/scripts/training_h2o.py
+++ b/src/edvise/scripts/training_h2o.py
@@ -571,6 +571,24 @@ class TrainingTask:
                 self.args.DB_workspace,
             )
 
+    def _resolve_advisor_output_table_path(self) -> str:
+        """
+        Resolve the gold table path to write training advisor output to.
+
+        Prefers an explicit ``datasets.gold.advisor_output.train_table_path`` from the
+        project config (needed when multiple legacy models share one institution's gold
+        schema, e.g. UNT freshmen vs. transfer, or JJC's per-checkpoint CUSP models —
+        otherwise they'd all collide on the same hardcoded ``{gold_table_path}.advisor_output``
+        table). Falls back to the legacy hardcoded path for schools that don't configure it.
+        """
+        if self.spec.schema_type == "legacy":
+            gold_datasets = getattr(self.cfg.datasets, "gold", None) or {}
+            advisor_cfg = gold_datasets.get("advisor_output")
+            configured_path = getattr(advisor_cfg, "train_table_path", None) if advisor_cfg else None
+            if configured_path:
+                return configured_path
+        return f"{self.args.gold_table_path}.advisor_output"
+
     def make_predictions(self, df_modeling: pd.DataFrame) -> None:
         if self.cfg.model is None:
             raise ValueError("cfg.model is required for predictions")
@@ -620,9 +638,10 @@ class TrainingTask:
             )
 
             # write gold artifacts
+            advisor_output_table_path = self._resolve_advisor_output_table_path()
             dataio.write.to_delta_table(
                 df=out.top_features_result,
-                table_path=f"{self.args.gold_table_path}.advisor_output",
+                table_path=advisor_output_table_path,
                 spark_session=self.spark_session,
             )
 


### PR DESCRIPTION
## Summary
- `training_h2o.py` hardcoded the training advisor-output write to `{gold_table_path}.advisor_output`, where `gold_table_path` is derived per institution, not per model.
- Legacy institutions with multiple models sharing one institution's gold schema (e.g. UNT freshmen/transfer, JJC's per-checkpoint CUSP models) would silently overwrite each other's advisor-output table when trained back-to-back.
- Added `TrainingTask._resolve_advisor_output_table_path()`, which prefers an explicit `cfg.datasets.gold.advisor_output.train_table_path` from the project config when set, falling back to the old hardcoded institution-level path otherwise.
- Scoped to `schema_type == "legacy"` only — PDP/ES behavior and table paths are unchanged.
- Companion fix in [datakind/student-success-intervention](https://github.com/datakind/student-success-intervention/pull/new/fix/jjc-advisor-output-table-collision) updates JJC's postprocessing reader and configs to match, and UNT's config/postprocessing were already fixed in a prior change on the `UNT/InferenceRefactoring` branch.

## Test plan
- [ ] Run `training_h2o` for a legacy institution whose config sets `datasets.gold.advisor_output.train_table_path` (e.g. UNT) and confirm it writes to the configured table instead of the hardcoded `{gold_table_path}.advisor_output`.
- [ ] Run `training_h2o` for a legacy institution that does *not* set this config key and confirm it still falls back to `{gold_table_path}.advisor_output` (no behavior change).
- [ ] Run `training_h2o` for a PDP or ES institution and confirm behavior is unchanged (write path still `{gold_table_path}.advisor_output`).

Made with [Cursor](https://cursor.com)