### PR TITLE
fix: treat summer cohorts as end-year for retention max cutoff

### DIFF
--- a/src/edvise/targets/shared.py
+++ b/src/edvise/targets/shared.py
@@ -140,8 +140,8 @@ def get_students_with_second_year_in_dataset(
             from ``df[term_id_col]`` itself or as a manually specified value which
             may be different from the actual max value in ``df`` , depending on use case.
             Note: Value must be a string formatted as "YYYY[-YY]".
-            Spring/Summer cohorts use the calendar/end year (``2024-25 SPRING|SUMMER``
-            → 2025); Fall/Winter keep the start year.
+            Summer cohorts use the end year (``2024-25 SUMMER`` → 2025) so they share
+            the cutoff with Fall of that year; Fall/Winter/Spring keep the start year.
         student_id_cols: One or multiple columns uniquely identifying students.
         cohort_id_col: Column used to uniquely identify student cohorts.
         term_id_col: Colum used to uniquely identify academic terms.
@@ -160,9 +160,9 @@ def get_students_with_second_year_in_dataset(
         # assume every value for a student's cohort id is the same, so "first" is fine
         .agg(student_cohort_id=(cohort_id_col, "first"))
         .assign(
-            # FALL/WINTER → start year; SPRING/SUMMER → end year
+            # Summer → end year (like following Fall); other seasons keep start year
             student_cohort_year=lambda df: _extract_year_from_id(
-                df["student_cohort_id"], roll_spring_summer=True
+                df["student_cohort_id"], summer_as_end_year=True
             ),
             max_academic_year=max_academic_year,  # type: ignore
         )
@@ -188,18 +188,17 @@ def _log_labelable_students(
 
 
 def _extract_year_from_id(
-    ser: pd.Series, *, roll_spring_summer: bool = False
+    ser: pd.Series, *, summer_as_end_year: bool = False
 ) -> pd.Series:
     """Extract leading YYYY from ids like ``2024-25 FALL``.
 
-    Term order is always FALL → WINTER → SPRING → SUMMER. When
-    ``roll_spring_summer`` is True, SPRING/SUMMER use the end year
-    (``2024-25 SPRING|SUMMER`` → 2025); FALL/WINTER keep the start year.
+    When ``summer_as_end_year`` is True, SUMMER uses the academic-year end
+    (``2024-25 SUMMER`` → 2025) so it shares the ``max_academic_year`` cutoff with
+    the following Fall. Spring stays on the start year (Spring 2025 retains into
+    Spring 2026 under academic year 2025-26).
     """
     s = ser.astype("string")
     year = s.str.extract(r"^(\d{4})", expand=False).astype("Int32")
-    if roll_spring_summer:
-        year = year + s.str.contains(r"(?i)\b(?:SPRING|SUMMER)\b", na=False).astype(
-            "Int32"
-        )
+    if summer_as_end_year:
+        year = year + s.str.contains(r"(?i)\bSUMMER\b", na=False).astype("Int32")
     return year

--- a/src/edvise/targets/shared.py
+++ b/src/edvise/targets/shared.py
@@ -199,7 +199,7 @@ def _extract_year_from_id(
     s = ser.astype("string")
     year = s.str.extract(r"^(\d{4})", expand=False).astype("Int32")
     if roll_spring_summer:
-        year = year + s.str.contains(
-            r"(?i)\b(?:SPRING|SUMMER)\b", na=False
-        ).astype("Int32")
+        year = year + s.str.contains(r"(?i)\b(?:SPRING|SUMMER)\b", na=False).astype(
+            "Int32"
+        )
     return year

--- a/src/edvise/targets/shared.py
+++ b/src/edvise/targets/shared.py
@@ -140,6 +140,8 @@ def get_students_with_second_year_in_dataset(
             from ``df[term_id_col]`` itself or as a manually specified value which
             may be different from the actual max value in ``df`` , depending on use case.
             Note: Value must be a string formatted as "YYYY[-YY]".
+            Summer cohorts use the calendar/end year (``2024-25 SUMMER`` → 2025), matching
+            Fall of that year for this cutoff.
         student_id_cols: One or multiple columns uniquely identifying students.
         cohort_id_col: Column used to uniquely identify student cohorts.
         term_id_col: Colum used to uniquely identify academic terms.
@@ -158,8 +160,9 @@ def get_students_with_second_year_in_dataset(
         # assume every value for a student's cohort id is the same, so "first" is fine
         .agg(student_cohort_id=(cohort_id_col, "first"))
         .assign(
+            # Summer is calendar end-year (like Fall of that year); see _extract_year_from_id
             student_cohort_year=lambda df: _extract_year_from_id(
-                df["student_cohort_id"]
+                df["student_cohort_id"], summer_as_end_year=True
             ),
             max_academic_year=max_academic_year,  # type: ignore
         )
@@ -184,5 +187,16 @@ def _log_labelable_students(
     )
 
 
-def _extract_year_from_id(ser: pd.Series) -> pd.Series:
-    return ser.astype("string").str.extract(r"^(\d{4})", expand=False).astype("Int32")
+def _extract_year_from_id(
+    ser: pd.Series, *, summer_as_end_year: bool = False
+) -> pd.Series:
+    """Extract leading YYYY from ids like ``2024-25 FALL``.
+
+    When ``summer_as_end_year`` is True, SUMMER uses the academic-year end
+    (``2024-25 SUMMER`` → 2025), matching calendar Summer / following Fall.
+    """
+    s = ser.astype("string")
+    year = s.str.extract(r"^(\d{4})", expand=False).astype("Int32")
+    if summer_as_end_year:
+        year = year + s.str.contains(r"(?i)\bSUMMER\b", na=False).astype("Int32")
+    return year

--- a/src/edvise/targets/shared.py
+++ b/src/edvise/targets/shared.py
@@ -140,8 +140,8 @@ def get_students_with_second_year_in_dataset(
             from ``df[term_id_col]`` itself or as a manually specified value which
             may be different from the actual max value in ``df`` , depending on use case.
             Note: Value must be a string formatted as "YYYY[-YY]".
-            Summer cohorts use the calendar/end year (``2024-25 SUMMER`` → 2025), matching
-            Fall of that year for this cutoff.
+            Spring/Summer cohorts use the calendar/end year (``2024-25 SPRING|SUMMER``
+            → 2025); Fall/Winter keep the start year.
         student_id_cols: One or multiple columns uniquely identifying students.
         cohort_id_col: Column used to uniquely identify student cohorts.
         term_id_col: Colum used to uniquely identify academic terms.
@@ -160,9 +160,9 @@ def get_students_with_second_year_in_dataset(
         # assume every value for a student's cohort id is the same, so "first" is fine
         .agg(student_cohort_id=(cohort_id_col, "first"))
         .assign(
-            # Summer is calendar end-year (like Fall of that year); see _extract_year_from_id
+            # FALL/WINTER → start year; SPRING/SUMMER → end year
             student_cohort_year=lambda df: _extract_year_from_id(
-                df["student_cohort_id"], summer_as_end_year=True
+                df["student_cohort_id"], roll_spring_summer=True
             ),
             max_academic_year=max_academic_year,  # type: ignore
         )
@@ -188,15 +188,18 @@ def _log_labelable_students(
 
 
 def _extract_year_from_id(
-    ser: pd.Series, *, summer_as_end_year: bool = False
+    ser: pd.Series, *, roll_spring_summer: bool = False
 ) -> pd.Series:
     """Extract leading YYYY from ids like ``2024-25 FALL``.
 
-    When ``summer_as_end_year`` is True, SUMMER uses the academic-year end
-    (``2024-25 SUMMER`` → 2025), matching calendar Summer / following Fall.
+    Term order is always FALL → WINTER → SPRING → SUMMER. When
+    ``roll_spring_summer`` is True, SPRING/SUMMER use the end year
+    (``2024-25 SPRING|SUMMER`` → 2025); FALL/WINTER keep the start year.
     """
     s = ser.astype("string")
     year = s.str.extract(r"^(\d{4})", expand=False).astype("Int32")
-    if summer_as_end_year:
-        year = year + s.str.contains(r"(?i)\bSUMMER\b", na=False).astype("Int32")
+    if roll_spring_summer:
+        year = year + s.str.contains(
+            r"(?i)\b(?:SPRING|SUMMER)\b", na=False
+        ).astype("Int32")
     return year

--- a/tests/preprocessing/targets/pdp/test_retention.py
+++ b/tests/preprocessing/targets/pdp/test_retention.py
@@ -90,10 +90,9 @@ from edvise.targets import retention
                 },
             ).astype({"student_id": "string", "retention": "boolean"}),
             "2022-23",
-            # 2021-22 SPRING rolls to 2022 and is excluded when max is 2022
             pd.Series(
-                data=[False],
-                index=pd.Index(["01"], dtype="string", name="student_id"),
+                data=[False, True],
+                index=pd.Index(["01", "02"], dtype="string", name="student_id"),
                 name="target",
                 dtype="boolean",
             ),
@@ -116,7 +115,7 @@ from edvise.targets import retention
                 dtype="boolean",
             ),
         ),
-        # SPRING/SUMMER roll to end year; FALL/WINTER keep start year
+        # Summer rolls to end year (like Fall 2025); Spring keeps start year
         (
             pd.DataFrame(
                 {
@@ -141,11 +140,12 @@ from edvise.targets import retention
                 },
             ).astype({"student_id": "string", "retention": "boolean"}),
             "2025",
-            # 2023-24 FALL (2023), 2024-25 WINTER (2024), 2024-25 FALL (2024)
-            # excluded: SPRING/SUMMER 2024-25 (2025) and FALL 2025-26 (2025)
+            # kept: FALL/WINTER/SPRING 2024-25 (and earlier); excluded: SUMMER 2024-25, FALL 2025-26
             pd.Series(
-                data=[False, True, False],
-                index=pd.Index(["01", "02", "05"], dtype="string", name="student_id"),
+                data=[False, True, False, False],
+                index=pd.Index(
+                    ["01", "02", "03", "05"], dtype="string", name="student_id"
+                ),
                 name="target",
                 dtype="boolean",
             ),

--- a/tests/preprocessing/targets/pdp/test_retention.py
+++ b/tests/preprocessing/targets/pdp/test_retention.py
@@ -90,9 +90,10 @@ from edvise.targets import retention
                 },
             ).astype({"student_id": "string", "retention": "boolean"}),
             "2022-23",
+            # 2021-22 SPRING rolls to 2022 and is excluded when max is 2022
             pd.Series(
-                data=[False, True],
-                index=pd.Index(["01", "02"], dtype="string", name="student_id"),
+                data=[False],
+                index=pd.Index(["01"], dtype="string", name="student_id"),
                 name="target",
                 dtype="boolean",
             ),
@@ -115,20 +116,24 @@ from edvise.targets import retention
                 dtype="boolean",
             ),
         ),
-        # Summer 2024-25 is calendar Summer 2025 and shares the Fall 2025 cutoff
+        # SPRING/SUMMER roll to end year; FALL/WINTER keep start year
         (
             pd.DataFrame(
                 {
-                    "student_id": ["01", "02", "03", "04"],
-                    "retention": [True, False, True, False],
+                    "student_id": ["01", "02", "03", "04", "05", "06"],
+                    "retention": [True, False, True, False, True, False],
                     "cohort_id": [
                         "2023-24 FALL",
+                        "2024-25 WINTER",
+                        "2024-25 SPRING",
                         "2024-25 SUMMER",
                         "2024-25 FALL",
                         "2025-26 FALL",
                     ],
                     "term_id": [
                         "2023-24 FALL",
+                        "2024-25 WINTER",
+                        "2024-25 SPRING",
                         "2024-25 SUMMER",
                         "2024-25 FALL",
                         "2025-26 SUMMER",
@@ -136,9 +141,11 @@ from edvise.targets import retention
                 },
             ).astype({"student_id": "string", "retention": "boolean"}),
             "2025",
+            # 2023-24 FALL (2023), 2024-25 WINTER (2024), 2024-25 FALL (2024)
+            # excluded: SPRING/SUMMER 2024-25 (2025) and FALL 2025-26 (2025)
             pd.Series(
-                data=[False, False],
-                index=pd.Index(["01", "03"], dtype="string", name="student_id"),
+                data=[False, True, False],
+                index=pd.Index(["01", "02", "05"], dtype="string", name="student_id"),
                 name="target",
                 dtype="boolean",
             ),

--- a/tests/preprocessing/targets/pdp/test_retention.py
+++ b/tests/preprocessing/targets/pdp/test_retention.py
@@ -115,6 +115,34 @@ from edvise.targets import retention
                 dtype="boolean",
             ),
         ),
+        # Summer 2024-25 is calendar Summer 2025 and shares the Fall 2025 cutoff
+        (
+            pd.DataFrame(
+                {
+                    "student_id": ["01", "02", "03", "04"],
+                    "retention": [True, False, True, False],
+                    "cohort_id": [
+                        "2023-24 FALL",
+                        "2024-25 SUMMER",
+                        "2024-25 FALL",
+                        "2025-26 FALL",
+                    ],
+                    "term_id": [
+                        "2023-24 FALL",
+                        "2024-25 SUMMER",
+                        "2024-25 FALL",
+                        "2025-26 SUMMER",
+                    ],
+                },
+            ).astype({"student_id": "string", "retention": "boolean"}),
+            "2025",
+            pd.Series(
+                data=[False, False],
+                index=pd.Index(["01", "03"], dtype="string", name="student_id"),
+                name="target",
+                dtype="boolean",
+            ),
+        ),
     ],
 )
 def test_compute_target(df, max_academic_year, exp):


### PR DESCRIPTION
## Summary
- Bug: retention `max_academic_year` compared the academic-year **prefix** from `cohort_id`, so `2024-25 SUMMER` (Summer 2025) remained training-eligible when `max_academic_year = "2025"`. 
     - We need Summer 2025-26 and Fall 2026-27 data for this cohort. 
     - We don't actually have this, so they all get set to retained = True, which isn't correct.  
- Why summer is special: a Summer 2025 starter’s retention outcome needs Summer/Fall 2026 data, which we do not always have yet. Spring 2024-2025 is fine to keep — those students retain into Spring 2026, which we do have data for -  but the summer cohort is more similar to fall for retention purposes.
- Fall rightfully doesn't get included bc it's labeled Fall 2025-26. Summer should follow this pattern. 
- Fix: for the cohort cutoff only, treat SUMMER as the academic-year **end** year (`2024-25 SUMMER` → 2025) so it shares the boundary with Fall 2025. Fall / Winter / Spring keep the start year. Max-year inference is unchanged (still prefix-based).

With `max_academic_year = "2025"`:
| Cohort | Eligible? |
|---|---|
| `2024-25 FALL` / `WINTER` / `SPRING` | yes |
| `2024-25 SUMMER` | no |
| `2025-26 FALL` / `SPRING` | no |