### PR TITLE
feat(genai): mapping reference infrastructure

### DIFF
--- a/pipelines/genai_mapping/databricks.yml
+++ b/pipelines/genai_mapping/databricks.yml
@@ -5,6 +5,7 @@ bundle:
 include:
   - resources/github_genai_mapping_onboard.yml
   - resources/github_genai_mapping_execute.yml
+  - resources/github_genai_mapping_pin_reference.yml
 
 variables:
   git_commit:
@@ -50,6 +51,11 @@ targets:
             git_url: https://github.com/datakind/edvise
             git_provider: gitHub
             git_commit: ${var.git_commit}
+        edvise_genai_mapping_pin_reference_pipeline:
+          git_source:
+            git_url: https://github.com/datakind/edvise
+            git_provider: gitHub
+            git_commit: ${var.git_commit}
 
   prod:
     mode: production
@@ -65,6 +71,11 @@ targets:
             git_provider: gitHub
             git_tag: ${var.git_tag}
         edvise_genai_mapping_execute_pipeline:
+          git_source:
+            git_url: https://github.com/datakind/edvise
+            git_provider: gitHub
+            git_tag: ${var.git_tag}
+        edvise_genai_mapping_pin_reference_pipeline:
           git_source:
             git_url: https://github.com/datakind/edvise
             git_provider: gitHub

--- a/pipelines/genai_mapping/resources/github_genai_mapping_pin_reference.yml
+++ b/pipelines/genai_mapping/resources/github_genai_mapping_pin_reference.yml
@@ -1,7 +1,7 @@
 # Admin: publish (canonical) or pull (replica) gold few-shot refs under genai_mapping.references.
 #
-# staging (canonical): mode=publish — copy institution active/ → references/<id>/current/
-# dest (replica):      mode=pull    — copy references/ from source_catalog (default staging_sst_01);
+# dev (canonical):     mode=publish — copy institution active/ → references/<id>/current/
+# staging (replica):   mode=pull    — copy references/ from source_catalog (default dev_sst_02);
 #                                    does not read local active/
 resources:
   jobs:
@@ -62,7 +62,7 @@ resources:
         - name: reference_id
           default: ""
         - name: source_catalog
-          default: "staging_sst_01"
+          default: "dev_sst_02"
         - name: pipeline_version
           default: ${var.pipeline_version}
 

--- a/pipelines/genai_mapping/resources/github_genai_mapping_pin_reference.yml
+++ b/pipelines/genai_mapping/resources/github_genai_mapping_pin_reference.yml
@@ -1,4 +1,5 @@
 # Admin: pin gold few-shot artifacts into shared genai_mapping.references volume + registry.
+# reference_id = institution id; always copies that school's genai_mapping/active/.
 resources:
   jobs:
     edvise_genai_mapping_pin_reference_pipeline:
@@ -18,18 +19,8 @@ resources:
               - "{{job.parameters.catalog}}"
               - --reference_id
               - "{{job.parameters.reference_id}}"
-              - --source_institution_id
-              - "{{job.parameters.source_institution_id}}"
-              - --source
-              - "{{job.parameters.source}}"
-              - --onboard_run_id
-              - "{{job.parameters.onboard_run_id}}"
-              - --archetype
-              - "{{job.parameters.archetype}}"
               - --pipeline_version
               - "{{job.parameters.pipeline_version}}"
-              - --pinned_by
-              - "{{job.parameters.pinned_by}}"
           job_cluster_key: edvise-genai-mapping-pin-reference-cluster
           libraries:
             - pypi:
@@ -61,18 +52,8 @@ resources:
           default: ${var.DB_workspace}
         - name: reference_id
           default: ""
-        - name: source_institution_id
-          default: ""
-        - name: source
-          default: "active"
-        - name: onboard_run_id
-          default: ""
-        - name: archetype
-          default: ""
         - name: pipeline_version
           default: ${var.pipeline_version}
-        - name: pinned_by
-          default: ""
 
       permissions:
         - group_name: ${var.datakind_group_to_manage_workflow}

--- a/pipelines/genai_mapping/resources/github_genai_mapping_pin_reference.yml
+++ b/pipelines/genai_mapping/resources/github_genai_mapping_pin_reference.yml
@@ -1,5 +1,8 @@
-# Admin: pin gold few-shot artifacts into shared genai_mapping.references volume + registry.
-# reference_id = institution id; always copies that school's genai_mapping/active/.
+# Admin: publish (canonical) or pull (replica) gold few-shot refs under genai_mapping.references.
+#
+# staging (canonical): mode=publish — copy institution active/ → references/<id>/current/
+# dest (replica):      mode=pull    — copy references/ from source_catalog (default staging_sst_01);
+#                                    does not read local active/
 resources:
   jobs:
     edvise_genai_mapping_pin_reference_pipeline:
@@ -15,10 +18,14 @@ resources:
             python_file: src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
             source: GIT
             parameters:
+              - --mode
+              - "{{job.parameters.mode}}"
               - --catalog
               - "{{job.parameters.catalog}}"
               - --reference_id
               - "{{job.parameters.reference_id}}"
+              - --source_catalog
+              - "{{job.parameters.source_catalog}}"
               - --pipeline_version
               - "{{job.parameters.pipeline_version}}"
           job_cluster_key: edvise-genai-mapping-pin-reference-cluster
@@ -48,10 +55,14 @@ resources:
             num_workers: 0
 
       parameters:
+        - name: mode
+          default: "publish"
         - name: catalog
           default: ${var.DB_workspace}
         - name: reference_id
           default: ""
+        - name: source_catalog
+          default: "staging_sst_01"
         - name: pipeline_version
           default: ${var.pipeline_version}
 

--- a/pipelines/genai_mapping/resources/github_genai_mapping_pin_reference.yml
+++ b/pipelines/genai_mapping/resources/github_genai_mapping_pin_reference.yml
@@ -1,7 +1,7 @@
 # Admin: publish (canonical) or pull (replica) gold few-shot refs under genai_mapping.references.
 #
 # dev (canonical):     mode=publish — copy institution active/ → references/<id>/current/
-# staging (replica):   mode=pull    — copy references/ from source_catalog (default dev_sst_02);
+# staging (replica):   mode=pull    — copy references/ from fixed canonical catalog (dev_sst_02);
 #                                    does not read local active/
 resources:
   jobs:
@@ -24,8 +24,6 @@ resources:
               - "{{job.parameters.catalog}}"
               - --reference_id
               - "{{job.parameters.reference_id}}"
-              - --source_catalog
-              - "{{job.parameters.source_catalog}}"
               - --pipeline_version
               - "{{job.parameters.pipeline_version}}"
           job_cluster_key: edvise-genai-mapping-pin-reference-cluster
@@ -61,8 +59,6 @@ resources:
           default: ${var.DB_workspace}
         - name: reference_id
           default: ""
-        - name: source_catalog
-          default: "dev_sst_02"
         - name: pipeline_version
           default: ${var.pipeline_version}
 

--- a/pipelines/genai_mapping/resources/github_genai_mapping_pin_reference.yml
+++ b/pipelines/genai_mapping/resources/github_genai_mapping_pin_reference.yml
@@ -1,0 +1,81 @@
+# Admin: pin gold few-shot artifacts into shared genai_mapping.references volume + registry.
+resources:
+  jobs:
+    edvise_genai_mapping_pin_reference_pipeline:
+      name: edvise_genai_mapping_pin_reference
+      timeout_seconds: 1800
+      max_concurrent_runs: 1
+      queue:
+        enabled: true
+
+      tasks:
+        - task_key: pin_reference
+          spark_python_task:
+            python_file: src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
+            source: GIT
+            parameters:
+              - --catalog
+              - "{{job.parameters.catalog}}"
+              - --reference_id
+              - "{{job.parameters.reference_id}}"
+              - --source_institution_id
+              - "{{job.parameters.source_institution_id}}"
+              - --source
+              - "{{job.parameters.source}}"
+              - --onboard_run_id
+              - "{{job.parameters.onboard_run_id}}"
+              - --archetype
+              - "{{job.parameters.archetype}}"
+              - --pipeline_version
+              - "{{job.parameters.pipeline_version}}"
+              - --pinned_by
+              - "{{job.parameters.pinned_by}}"
+          job_cluster_key: edvise-genai-mapping-pin-reference-cluster
+          libraries:
+            - pypi:
+                package: pydantic~=2.10
+
+      job_clusters:
+        - job_cluster_key: edvise-genai-mapping-pin-reference-cluster
+          new_cluster:
+            cluster_name: ""
+            spark_version: 15.4.x-scala2.12
+            spark_conf:
+              spark.master: local[*, 4]
+              spark.databricks.cluster.profile: singleNode
+            gcp_attributes:
+              use_preemptible_executors: false
+              availability: ON_DEMAND_GCP
+              zone_id: HA
+            node_type_id: n2-standard-4
+            custom_tags:
+              ResourceClass: SingleNode
+              x-databricks-nextgen-cluster: "true"
+            enable_elastic_disk: true
+            data_security_mode: SINGLE_USER
+            runtime_engine: STANDARD
+            num_workers: 0
+
+      parameters:
+        - name: catalog
+          default: ${var.DB_workspace}
+        - name: reference_id
+          default: ""
+        - name: source_institution_id
+          default: ""
+        - name: source
+          default: "active"
+        - name: onboard_run_id
+          default: ""
+        - name: archetype
+          default: ""
+        - name: pipeline_version
+          default: ${var.pipeline_version}
+        - name: pinned_by
+          default: ""
+
+      permissions:
+        - group_name: ${var.datakind_group_to_manage_workflow}
+          level: CAN_MANAGE
+        - service_principal_name: ${var.ds_run_as}
+          level: CAN_MANAGE

--- a/pipelines/genai_mapping/resources/github_genai_mapping_pin_reference.yml
+++ b/pipelines/genai_mapping/resources/github_genai_mapping_pin_reference.yml
@@ -8,7 +8,7 @@ resources:
     edvise_genai_mapping_pin_reference_pipeline:
       name: edvise_genai_mapping_pin_reference
       timeout_seconds: 1800
-      max_concurrent_runs: 1
+      max_concurrent_runs: 5
       queue:
         enabled: true
 

--- a/pipelines/genai_mapping/resources/github_genai_mapping_pin_reference.yml
+++ b/pipelines/genai_mapping/resources/github_genai_mapping_pin_reference.yml
@@ -1,8 +1,8 @@
 # Admin: publish (canonical) or pull (replica) gold few-shot refs under genai_mapping.references.
 #
-# dev (canonical):     mode=publish — copy institution active/ → references/<id>/current/
-# staging (replica):   mode=pull    — copy references/ from fixed canonical catalog (dev_sst_02);
-#                                    does not read local active/
+# Action is derived from catalog (no mode param):
+#   catalog=dev_sst_02      → publish from institution active/
+#   catalog=staging_sst_01  → pull references/ from fixed canonical catalog (dev_sst_02)
 resources:
   jobs:
     edvise_genai_mapping_pin_reference_pipeline:
@@ -18,8 +18,6 @@ resources:
             python_file: src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
             source: GIT
             parameters:
-              - --mode
-              - "{{job.parameters.mode}}"
               - --catalog
               - "{{job.parameters.catalog}}"
               - --reference_id
@@ -53,8 +51,6 @@ resources:
             num_workers: 0
 
       parameters:
-        - name: mode
-          default: "publish"
         - name: catalog
           default: ${var.DB_workspace}
         - name: reference_id

--- a/src/edvise/configs/genai.py
+++ b/src/edvise/configs/genai.py
@@ -20,6 +20,8 @@ from edvise.genai.mapping.shared.pipeline_artifacts import (
 )
 from edvise.genai.mapping.shared.volume_paths import (
     bronze_volume_path_for_institution,
+    genai_reference_current_root,
+    genai_reference_root,
     resolve_genai_data_path,
     resolve_genai_inputs_toml_path,
     silver_genai_mapping_root,
@@ -31,6 +33,8 @@ __all__ = [
     "IdentityAgentInputsConfig",
     "SchoolMappingConfig",
     "bronze_volume_path_for_institution",
+    "genai_reference_current_root",
+    "genai_reference_root",
     "resolve_genai_data_path",
     "resolve_genai_inputs_toml_path",
     "silver_genai_mapping_root",

--- a/src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
+++ b/src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
@@ -2,28 +2,20 @@
 """
 Publish or pull a gold GenAI mapping reference under ``genai_mapping.references``.
 
-Modes
------
-``publish`` (canonical catalog, ``dev_sst_02``)
-    Copy that institution's ``genai_mapping/active/`` →
-    ``references/<reference_id>/current/`` + ``reference_pins`` row.
-    Use when blessing a new/updated gold few-shot set.
+Action is selected by ``--catalog`` (not a separate mode flag):
 
-``pull`` (replica catalog, ``staging_sst_01``)
-    Copy ``references/<reference_id>/current/`` from the fixed canonical catalog
-    (``dev_sst_02``) into this catalog. Does **not** read local ``active/``
-    (avoids divergent active overwriting the library). Requires volume read access
-    to the canonical catalog.
+* ``dev_sst_02`` — **publish** from that institution's ``genai_mapping/active/``
+* ``staging_sst_01`` — **pull** pinned bytes from ``dev_sst_02`` (ignores local ``active/``)
 
 Examples::
 
-    # Dev — publish from active/ (canonical)
+    # Dev — publish from active/
     python .../edvise_genai_pin_reference.py \\
-      --mode publish --catalog dev_sst_02 --reference_id my_school
+      --catalog dev_sst_02 --reference_id my_school
 
-    # Staging — pull fixed canonical catalog's pinned bytes (parity)
+    # Staging — pull from fixed canonical catalog
     python .../edvise_genai_pin_reference.py \\
-      --mode pull --catalog staging_sst_01 --reference_id my_school
+      --catalog staging_sst_01 --reference_id my_school
 """
 
 from __future__ import annotations
@@ -58,26 +50,25 @@ def main(argv: list[str] | None = None) -> int:
         DEFAULT_CANONICAL_REFERENCE_CATALOG,
         pin_reference_snapshot,
         pull_reference_snapshot,
+        resolve_pin_mode,
         upsert_reference_pin_row,
     )
 
     parser = argparse.ArgumentParser(
         description=(
-            "Publish (from active/) or pull (from canonical catalog) "
-            "GenAI mapping reference few-shot artifacts"
+            "Publish or pull GenAI mapping reference few-shot artifacts. "
+            f"catalog={DEFAULT_CANONICAL_REFERENCE_CATALOG} publishes; "
+            "catalog=staging_sst_01 pulls from the canonical catalog."
         )
     )
     parser.add_argument(
-        "--mode",
+        "--catalog",
         required=True,
-        choices=["publish", "pull"],
         help=(
-            "publish: pin from local active/ (canonical). "
-            f"pull: copy references/current/ from {DEFAULT_CANONICAL_REFERENCE_CATALOG} "
-            "(replica; no local active/)."
+            f"UC catalog for this job: {DEFAULT_CANONICAL_REFERENCE_CATALOG} "
+            "(publish) or staging_sst_01 (pull)"
         ),
     )
-    parser.add_argument("--catalog", required=True, help="UC catalog for this job run")
     parser.add_argument(
         "--reference_id",
         required=True,
@@ -108,8 +99,9 @@ def main(argv: list[str] | None = None) -> int:
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
 
+    mode = resolve_pin_mode(args.catalog)
     write_history = not args.no_history_copy
-    if args.mode == "publish":
+    if mode == "publish":
         pin = pin_reference_snapshot(
             catalog=args.catalog,
             reference_id=args.reference_id,
@@ -150,7 +142,7 @@ def main(argv: list[str] | None = None) -> int:
         args.catalog,
         pin["reference_id"],
         pin["content_hash"],
-        args.mode,
+        mode,
     )
     return 0
 

--- a/src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
+++ b/src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
@@ -31,7 +31,24 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import sys
+
+# Layout: <git_root>/src/edvise/genai/mapping/scripts/<this_file>
+# `import edvise` needs <git_root>/src on sys.path (package is <git_root>/src/edvise/).
+# Databricks spark_python_task often exec()s this file without defining __file__.
+_here = globals().get("__file__")
+if _here:
+    _script_dir = os.path.dirname(os.path.abspath(_here))
+else:
+    _argv0 = os.path.abspath(sys.argv[0]) if sys.argv else ""
+    if _argv0.endswith(".py") and os.path.isfile(_argv0):
+        _script_dir = os.path.dirname(_argv0)
+    else:
+        _script_dir = os.path.abspath(os.getcwd())
+_src_root = os.path.abspath(os.path.join(_script_dir, "..", "..", "..", ".."))
+if os.path.isdir(_src_root) and _src_root not in sys.path:
+    sys.path.insert(0, _src_root)
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
+++ b/src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
@@ -10,9 +10,10 @@ Modes
     Use when blessing a new/updated gold few-shot set.
 
 ``pull`` (replica catalog, ``staging_sst_01``)
-    Copy ``references/<reference_id>/current/`` from ``source_catalog`` into this
-    catalog. Does **not** read local ``active/`` (avoids divergent active overwriting
-    the library). Requires volume read access to the source catalog.
+    Copy ``references/<reference_id>/current/`` from the fixed canonical catalog
+    (``dev_sst_02``) into this catalog. Does **not** read local ``active/``
+    (avoids divergent active overwriting the library). Requires volume read access
+    to the canonical catalog.
 
 Examples::
 
@@ -20,10 +21,9 @@ Examples::
     python .../edvise_genai_pin_reference.py \\
       --mode publish --catalog dev_sst_02 --reference_id my_school
 
-    # Staging — pull dev's pinned bytes (parity)
+    # Staging — pull fixed canonical catalog's pinned bytes (parity)
     python .../edvise_genai_pin_reference.py \\
-      --mode pull --catalog staging_sst_01 --reference_id my_school \\
-      --source_catalog dev_sst_02
+      --mode pull --catalog staging_sst_01 --reference_id my_school
 """
 
 from __future__ import annotations
@@ -73,7 +73,8 @@ def main(argv: list[str] | None = None) -> int:
         choices=["publish", "pull"],
         help=(
             "publish: pin from local active/ (canonical). "
-            "pull: copy references/current/ from source_catalog (replica; no local active/)."
+            f"pull: copy references/current/ from {DEFAULT_CANONICAL_REFERENCE_CATALOG} "
+            "(replica; no local active/)."
         ),
     )
     parser.add_argument("--catalog", required=True, help="UC catalog for this job run")
@@ -81,14 +82,6 @@ def main(argv: list[str] | None = None) -> int:
         "--reference_id",
         required=True,
         help="Institution id / library slot under references/",
-    )
-    parser.add_argument(
-        "--source_catalog",
-        default=DEFAULT_CANONICAL_REFERENCE_CATALOG,
-        help=(
-            "pull only: catalog to copy references/ from "
-            f"(default: {DEFAULT_CANONICAL_REFERENCE_CATALOG})"
-        ),
     )
     parser.add_argument(
         "--pipeline_version",
@@ -128,10 +121,14 @@ def main(argv: list[str] | None = None) -> int:
         pin = pull_reference_snapshot(
             catalog=args.catalog,
             reference_id=args.reference_id,
-            source_catalog=args.source_catalog,
+            source_catalog=DEFAULT_CANONICAL_REFERENCE_CATALOG,
             write_history_copy=write_history,
         )
-        LOGGER.info("Pulled reference:\n%s", json.dumps(pin, indent=2))
+        LOGGER.info(
+            "Pulled reference from %s:\n%s",
+            DEFAULT_CANONICAL_REFERENCE_CATALOG,
+            json.dumps(pin, indent=2),
+        )
 
     if args.skip_uc_registry:
         LOGGER.warning("Skipped UC reference_pins upsert (--skip_uc_registry)")

--- a/src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
+++ b/src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
@@ -159,4 +159,8 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    # Databricks exec()s this file in an IPython kernel, where even SystemExit(0)
+    # is reported as a failed workload; only surface non-zero exits.
+    _rc = main()
+    if _rc:
+        raise SystemExit(_rc)

--- a/src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
+++ b/src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
@@ -1,23 +1,29 @@
 #!/usr/bin/env python3
 """
-Pin a gold GenAI mapping reference into the shared ``genai_mapping.references`` volume.
+Publish or pull a gold GenAI mapping reference under ``genai_mapping.references``.
 
-Copies few-shot artifacts from that institution's ``genai_mapping/active/`` into::
+Modes
+-----
+``publish`` (canonical catalog, typically ``staging_sst_01``)
+    Copy that institution's ``genai_mapping/active/`` →
+    ``references/<reference_id>/current/`` + ``reference_pins`` row.
+    Use when blessing a new/updated gold few-shot set.
 
-    /Volumes/<catalog>/genai_mapping/references/<reference_id>/current/
+``pull`` (replica catalog, typically ``dev_sst_02``)
+    Copy ``references/<reference_id>/current/`` from ``source_catalog`` into this
+    catalog. Does **not** read local ``active/`` (avoids divergent active overwriting
+    the library). Requires volume read access to the source catalog.
 
-``reference_id`` is the institution id (library slot = school). Provenance
-(``source_onboard_run_id``, ``pipeline_version``) is read from
-``genai_active_registry.json`` under ``active/``.
+Examples::
 
-Writes ``genai_reference_pin.json`` (content hash) and upserts
-``{catalog}.genai_mapping.reference_pins``.
+    # Staging — publish from active/
+    python .../edvise_genai_pin_reference.py \\
+      --mode publish --catalog staging_sst_01 --reference_id my_school
 
-Example::
-
-    python src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py \\
-      --catalog dev_sst_02 \\
-      --reference_id my_school
+    # Dev — pull staging's pinned bytes (parity)
+    python .../edvise_genai_pin_reference.py \\
+      --mode pull --catalog dev_sst_02 --reference_id my_school \\
+      --source_catalog staging_sst_01
 """
 
 from __future__ import annotations
@@ -31,24 +37,48 @@ LOGGER = logging.getLogger(__name__)
 
 
 def main(argv: list[str] | None = None) -> int:
+    from edvise.genai.mapping.shared.reference_pin import (
+        DEFAULT_CANONICAL_REFERENCE_CATALOG,
+        pin_reference_snapshot,
+        pull_reference_snapshot,
+        upsert_reference_pin_row,
+    )
+
     parser = argparse.ArgumentParser(
         description=(
-            "Pin GenAI mapping few-shot artifacts from institution active/ "
-            "to shared references/<reference_id>/current/"
+            "Publish (from active/) or pull (from canonical catalog) "
+            "GenAI mapping reference few-shot artifacts"
         )
     )
-    parser.add_argument("--catalog", required=True, help="UC catalog (e.g. dev_sst_02)")
+    parser.add_argument(
+        "--mode",
+        required=True,
+        choices=["publish", "pull"],
+        help=(
+            "publish: pin from local active/ (canonical). "
+            "pull: copy references/current/ from source_catalog (replica; no local active/)."
+        ),
+    )
+    parser.add_argument("--catalog", required=True, help="UC catalog for this job run")
     parser.add_argument(
         "--reference_id",
         required=True,
-        help="Institution id to pin (slot under references/ and source of active/)",
+        help="Institution id / library slot under references/",
+    )
+    parser.add_argument(
+        "--source_catalog",
+        default=DEFAULT_CANONICAL_REFERENCE_CATALOG,
+        help=(
+            "pull only: catalog to copy references/ from "
+            f"(default: {DEFAULT_CANONICAL_REFERENCE_CATALOG})"
+        ),
     )
     parser.add_argument(
         "--pipeline_version",
         default="",
         help=(
-            "Optional override; default is pipeline_version from "
-            "genai_active_registry.json under that school's active/"
+            "publish only: optional override; default from "
+            "genai_active_registry.json under active/"
         ),
     )
     parser.add_argument(
@@ -68,18 +98,23 @@ def main(argv: list[str] | None = None) -> int:
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
 
-    from edvise.genai.mapping.shared.reference_pin import (
-        pin_reference_snapshot,
-        upsert_reference_pin_row,
-    )
-
-    pin = pin_reference_snapshot(
-        catalog=args.catalog,
-        reference_id=args.reference_id,
-        pipeline_version=args.pipeline_version or None,
-        write_history_copy=not args.no_history_copy,
-    )
-    LOGGER.info("Pinned reference:\n%s", json.dumps(pin, indent=2))
+    write_history = not args.no_history_copy
+    if args.mode == "publish":
+        pin = pin_reference_snapshot(
+            catalog=args.catalog,
+            reference_id=args.reference_id,
+            pipeline_version=args.pipeline_version or None,
+            write_history_copy=write_history,
+        )
+        LOGGER.info("Published reference:\n%s", json.dumps(pin, indent=2))
+    else:
+        pin = pull_reference_snapshot(
+            catalog=args.catalog,
+            reference_id=args.reference_id,
+            source_catalog=args.source_catalog,
+            write_history_copy=write_history,
+        )
+        LOGGER.info("Pulled reference:\n%s", json.dumps(pin, indent=2))
 
     if args.skip_uc_registry:
         LOGGER.warning("Skipped UC reference_pins upsert (--skip_uc_registry)")
@@ -97,10 +132,11 @@ def main(argv: list[str] | None = None) -> int:
 
     upsert_reference_pin_row(args.catalog, pin, spark=spark)
     LOGGER.info(
-        "Registry updated: %s.genai_mapping.reference_pins reference_id=%r hash=%r",
+        "Registry updated: %s.genai_mapping.reference_pins reference_id=%r hash=%r mode=%s",
         args.catalog,
         pin["reference_id"],
         pin["content_hash"],
+        args.mode,
     )
     return 0
 

--- a/src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
+++ b/src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
@@ -4,26 +4,26 @@ Publish or pull a gold GenAI mapping reference under ``genai_mapping.references`
 
 Modes
 -----
-``publish`` (canonical catalog, typically ``staging_sst_01``)
+``publish`` (canonical catalog, ``dev_sst_02``)
     Copy that institution's ``genai_mapping/active/`` →
     ``references/<reference_id>/current/`` + ``reference_pins`` row.
     Use when blessing a new/updated gold few-shot set.
 
-``pull`` (replica catalog, typically ``dev_sst_02``)
+``pull`` (replica catalog, ``staging_sst_01``)
     Copy ``references/<reference_id>/current/`` from ``source_catalog`` into this
     catalog. Does **not** read local ``active/`` (avoids divergent active overwriting
     the library). Requires volume read access to the source catalog.
 
 Examples::
 
-    # Staging — publish from active/
+    # Dev — publish from active/ (canonical)
     python .../edvise_genai_pin_reference.py \\
-      --mode publish --catalog staging_sst_01 --reference_id my_school
+      --mode publish --catalog dev_sst_02 --reference_id my_school
 
-    # Dev — pull staging's pinned bytes (parity)
+    # Staging — pull dev's pinned bytes (parity)
     python .../edvise_genai_pin_reference.py \\
-      --mode pull --catalog dev_sst_02 --reference_id my_school \\
-      --source_catalog staging_sst_01
+      --mode pull --catalog staging_sst_01 --reference_id my_school \\
+      --source_catalog dev_sst_02
 """
 
 from __future__ import annotations

--- a/src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
+++ b/src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
@@ -2,26 +2,22 @@
 """
 Pin a gold GenAI mapping reference into the shared ``genai_mapping.references`` volume.
 
-Copies few-shot artifacts from a school's ``active/`` (default) or a specific onboard run
-into::
+Copies few-shot artifacts from that institution's ``genai_mapping/active/`` into::
 
     /Volumes/<catalog>/genai_mapping/references/<reference_id>/current/
 
+``reference_id`` is the institution id (library slot = school). Provenance
+(``source_onboard_run_id``, ``pipeline_version``) is read from
+``genai_active_registry.json`` under ``active/``.
+
 Writes ``genai_reference_pin.json`` (content hash) and upserts
 ``{catalog}.genai_mapping.reference_pins``.
-
-Does **not** change SMA few-shot resolution (still reads school ``active/`` until a follow-up
-change). Safe to run after HITL + promote for each gold reference school.
 
 Example::
 
     python src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py \\
       --catalog dev_sst_02 \\
-      --reference_id ref_cc_student_term_01 \\
-      --source_institution_id my_school \\
-      --source active \\
-      --archetype cc_student_term \\
-      --pinned_by vishakh
+      --reference_id my_school
 """
 
 from __future__ import annotations
@@ -36,44 +32,24 @@ LOGGER = logging.getLogger(__name__)
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Pin GenAI mapping few-shot artifacts to shared references/ volume"
+        description=(
+            "Pin GenAI mapping few-shot artifacts from institution active/ "
+            "to shared references/<reference_id>/current/"
+        )
     )
     parser.add_argument("--catalog", required=True, help="UC catalog (e.g. dev_sst_02)")
     parser.add_argument(
         "--reference_id",
         required=True,
-        help="Library slot id (opaque ok), used as folder name under references/",
-    )
-    parser.add_argument(
-        "--source_institution_id",
-        required=True,
-        help="Institution whose silver volume provides the artifacts to pin",
-    )
-    parser.add_argument(
-        "--source",
-        default="active",
-        choices=["active", "onboard_run"],
-        help="Copy from genai_mapping/active/ (default) or a specific onboard run tree",
-    )
-    parser.add_argument(
-        "--onboard_run_id",
-        default="",
-        help="Required when --source=onboard_run; optional override when source=active",
-    )
-    parser.add_argument(
-        "--archetype",
-        default="",
-        help="Optional label (e.g. cc_student_term, 4yr_banner) stored on the pin",
+        help="Institution id to pin (slot under references/ and source of active/)",
     )
     parser.add_argument(
         "--pipeline_version",
         default="",
-        help="Optional; defaults from genai_active_registry.json when pinning from active/",
-    )
-    parser.add_argument(
-        "--pinned_by",
-        required=True,
-        help="Operator identity recorded on the pin (required)",
+        help=(
+            "Optional override; default is pipeline_version from "
+            "genai_active_registry.json under that school's active/"
+        ),
     )
     parser.add_argument(
         "--no_history_copy",
@@ -100,11 +76,6 @@ def main(argv: list[str] | None = None) -> int:
     pin = pin_reference_snapshot(
         catalog=args.catalog,
         reference_id=args.reference_id,
-        source_institution_id=args.source_institution_id,
-        pinned_by=args.pinned_by,
-        source=args.source,  # type: ignore[arg-type]
-        onboard_run_id=args.onboard_run_id or None,
-        archetype=args.archetype or None,
         pipeline_version=args.pipeline_version or None,
         write_history_copy=not args.no_history_copy,
     )

--- a/src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
+++ b/src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Pin a gold GenAI mapping reference into the shared ``genai_mapping.references`` volume.
+
+Copies few-shot artifacts from a school's ``active/`` (default) or a specific onboard run
+into::
+
+    /Volumes/<catalog>/genai_mapping/references/<reference_id>/current/
+
+Writes ``genai_reference_pin.json`` (content hash) and upserts
+``{catalog}.genai_mapping.reference_pins``.
+
+Does **not** change SMA few-shot resolution (still reads school ``active/`` until a follow-up
+change). Safe to run after HITL + promote for each gold reference school.
+
+Example::
+
+    python src/edvise/genai/mapping/scripts/edvise_genai_pin_reference.py \\
+      --catalog dev_sst_02 \\
+      --reference_id ref_cc_student_term_01 \\
+      --source_institution_id my_school \\
+      --source active \\
+      --archetype cc_student_term \\
+      --pinned_by vishakh
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+
+LOGGER = logging.getLogger(__name__)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Pin GenAI mapping few-shot artifacts to shared references/ volume"
+    )
+    parser.add_argument("--catalog", required=True, help="UC catalog (e.g. dev_sst_02)")
+    parser.add_argument(
+        "--reference_id",
+        required=True,
+        help="Library slot id (opaque ok), used as folder name under references/",
+    )
+    parser.add_argument(
+        "--source_institution_id",
+        required=True,
+        help="Institution whose silver volume provides the artifacts to pin",
+    )
+    parser.add_argument(
+        "--source",
+        default="active",
+        choices=["active", "onboard_run"],
+        help="Copy from genai_mapping/active/ (default) or a specific onboard run tree",
+    )
+    parser.add_argument(
+        "--onboard_run_id",
+        default="",
+        help="Required when --source=onboard_run; optional override when source=active",
+    )
+    parser.add_argument(
+        "--archetype",
+        default="",
+        help="Optional label (e.g. cc_student_term, 4yr_banner) stored on the pin",
+    )
+    parser.add_argument(
+        "--pipeline_version",
+        default="",
+        help="Optional; defaults from genai_active_registry.json when pinning from active/",
+    )
+    parser.add_argument(
+        "--pinned_by",
+        required=True,
+        help="Operator identity recorded on the pin (required)",
+    )
+    parser.add_argument(
+        "--no_history_copy",
+        action="store_true",
+        help="Skip writing references/<id>/vYYYYMMDD_<hash12>/ history snapshot",
+    )
+    parser.add_argument(
+        "--skip_uc_registry",
+        action="store_true",
+        help="Only write volume files + pin JSON; skip reference_pins Delta upsert",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    from edvise.genai.mapping.shared.reference_pin import (
+        pin_reference_snapshot,
+        upsert_reference_pin_row,
+    )
+
+    pin = pin_reference_snapshot(
+        catalog=args.catalog,
+        reference_id=args.reference_id,
+        source_institution_id=args.source_institution_id,
+        pinned_by=args.pinned_by,
+        source=args.source,  # type: ignore[arg-type]
+        onboard_run_id=args.onboard_run_id or None,
+        archetype=args.archetype or None,
+        pipeline_version=args.pipeline_version or None,
+        write_history_copy=not args.no_history_copy,
+    )
+    LOGGER.info("Pinned reference:\n%s", json.dumps(pin, indent=2))
+
+    if args.skip_uc_registry:
+        LOGGER.warning("Skipped UC reference_pins upsert (--skip_uc_registry)")
+        return 0
+
+    try:
+        from pyspark.sql import SparkSession
+
+        spark = SparkSession.getActiveSession() or SparkSession.builder.getOrCreate()
+    except Exception as e:  # noqa: BLE001
+        LOGGER.error(
+            "Spark unavailable (%s); re-run on Databricks or pass --skip_uc_registry", e
+        )
+        return 1
+
+    upsert_reference_pin_row(args.catalog, pin, spark=spark)
+    LOGGER.info(
+        "Registry updated: %s.genai_mapping.reference_pins reference_id=%r hash=%r",
+        args.catalog,
+        pin["reference_id"],
+        pin["content_hash"],
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/edvise/genai/mapping/shared/reference_pin.py
+++ b/src/edvise/genai/mapping/shared/reference_pin.py
@@ -11,9 +11,9 @@ plus ``genai_reference_pin.json`` (local hash metadata) and a row in
 
 Two job modes:
 
-* ``publish`` — copy from local ``active/`` (canonical catalog, e.g. staging).
-* ``pull`` — copy ``references/<id>/current/`` from ``source_catalog`` into this catalog;
-  does not read local ``active/`` (replica parity).
+* ``publish`` — copy from local ``active/`` (canonical catalog, ``dev_sst_02``).
+* ``pull`` — copy ``references/<id>/current/`` from ``source_catalog`` into this catalog
+  (replica, e.g. ``staging_sst_01``); does not read local ``active/`` (parity).
 """
 
 from __future__ import annotations
@@ -52,7 +52,7 @@ SourceKind = Literal["active", "onboard_run"]
 PinMode = Literal["publish", "pull"]
 
 # Canonical catalog for gold references; pull mode defaults to this as source.
-DEFAULT_CANONICAL_REFERENCE_CATALOG: str = "staging_sst_01"
+DEFAULT_CANONICAL_REFERENCE_CATALOG: str = "dev_sst_02"
 
 
 def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:

--- a/src/edvise/genai/mapping/shared/reference_pin.py
+++ b/src/edvise/genai/mapping/shared/reference_pin.py
@@ -217,50 +217,40 @@ def pin_reference_snapshot(
     *,
     catalog: str,
     reference_id: str,
-    source_institution_id: str,
-    pinned_by: str,
-    source: SourceKind = "active",
-    onboard_run_id: str | None = None,
-    archetype: str | None = None,
     pipeline_version: str | None = None,
     write_history_copy: bool = True,
 ) -> dict[str, Any]:
     """
-    Copy source artifacts into ``references/<reference_id>/current/`` and write pin metadata.
+    Copy ``active/`` artifacts for ``reference_id`` into
+    ``references/<reference_id>/current/`` and write pin metadata.
 
-    Returns the pin payload (also written as ``genai_reference_pin.json``). Does **not** write
-    the UC ``reference_pins`` table — callers use :func:`upsert_reference_pin_row` for that.
+    ``reference_id`` is both the library slot and the institution whose silver
+    ``genai_mapping/active/`` is the source. ``source_onboard_run_id`` and
+    ``pipeline_version`` (when not passed) are read from ``genai_active_registry.json``.
+
+    Returns the pin payload (also written as ``genai_reference_pin.json``). Does **not**
+    write the UC ``reference_pins`` table — callers use :func:`upsert_reference_pin_row`.
     """
     ref = str(reference_id).strip()
-    by = str(pinned_by).strip()
     if not ref:
         raise ValueError("reference_id must be non-empty")
-    if not by:
-        raise ValueError("pinned_by must be non-empty")
 
     source_paths = resolve_reference_source_paths(
         catalog=catalog,
-        source_institution_id=source_institution_id,
-        source=source,
-        onboard_run_id=onboard_run_id,
+        source_institution_id=ref,
+        source="active",
     )
 
-    # Provenance defaults from active registry when pinning from active/.
-    resolved_run_id = str(onboard_run_id or "").strip() or None
+    resolved_run_id: str | None = None
     resolved_pipeline = str(pipeline_version or "").strip() or None
-    if source == "active":
-        active_root = (
-            Path(silver_genai_mapping_root(source_institution_id, catalog=catalog))
-            / "active"
-        )
-        reg = read_genai_active_registry(active_root)
-        if reg:
-            if not resolved_run_id:
-                rid = str(reg.get("onboard_run_id") or "").strip()
-                resolved_run_id = rid or None
-            if not resolved_pipeline:
-                pver = str(reg.get("pipeline_version") or "").strip()
-                resolved_pipeline = pver or None
+    active_root = Path(silver_genai_mapping_root(ref, catalog=catalog)) / "active"
+    reg = read_genai_active_registry(active_root)
+    if reg:
+        rid = str(reg.get("onboard_run_id") or "").strip()
+        resolved_run_id = rid or None
+        if not resolved_pipeline:
+            pver = str(reg.get("pipeline_version") or "").strip()
+            resolved_pipeline = pver or None
 
     content_hash = compute_reference_content_hash(source_paths)
     pinned_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -277,26 +267,22 @@ def pin_reference_snapshot(
     payload: dict[str, Any] = {
         "schema_version": _REFERENCE_PIN_SCHEMA_VERSION,
         "reference_id": ref,
-        "source_institution_id": str(source_institution_id).strip(),
+        "source_institution_id": ref,
         "pinned_at": pinned_at,
-        "pinned_by": by,
         "content_hash": content_hash,
         "artifacts": artifact_names,
-        "source": source,
+        "source": "active",
         "uc_catalog": str(catalog).strip(),
     }
     if resolved_run_id:
         payload["source_onboard_run_id"] = resolved_run_id
     if resolved_pipeline:
         payload["pipeline_version"] = resolved_pipeline
-    if archetype and str(archetype).strip():
-        payload["archetype"] = str(archetype).strip()
 
     pin_path = current / GENAI_REFERENCE_PIN_BASENAME
     _atomic_write_json(pin_path, payload)
     LOGGER.info("Wrote %s (content_hash=%r)", pin_path, content_hash)
 
-    # Confirm round-trip hash matches what we just wrote.
     verify_reference_pin_hash(current)
 
     if write_history_copy:

--- a/src/edvise/genai/mapping/shared/reference_pin.py
+++ b/src/edvise/genai/mapping/shared/reference_pin.py
@@ -1,0 +1,471 @@
+"""
+Pin GenAI mapping few-shot artifacts into the shared ``genai_mapping.references`` volume.
+
+School ``active/`` (and onboard runs) remain mutable execute/ops state. Gold references are an
+explicit copy into::
+
+    /Volumes/<catalog>/genai_mapping/references/<reference_id>/current/
+
+plus ``genai_reference_pin.json`` (local hash metadata) and a row in
+``{catalog}.genai_mapping.reference_pins``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Literal
+
+from edvise.genai.mapping.shared.active_promotion import read_genai_active_registry
+from edvise.genai.mapping.shared.volume_paths import (
+    genai_reference_current_root,
+    silver_genai_mapping_root,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+GENAI_REFERENCE_PIN_BASENAME: str = "genai_reference_pin.json"
+"""Sidecar under ``references/<id>/current/`` recording pin provenance + content hash."""
+
+_REFERENCE_PIN_SCHEMA_VERSION: int = 1
+
+# Required for SMA few-shot; hashed whenever present under the pin directory.
+REFERENCE_PIN_REQUIRED_ARTIFACTS: tuple[str, ...] = (
+    "manifest_map.json",
+    "transformation_map.json",
+)
+
+# Optional but useful for selection / debugging; included in the hash when copied.
+REFERENCE_PIN_OPTIONAL_ARTIFACTS: tuple[str, ...] = ("enriched_schema_contract.json",)
+
+SourceKind = Literal["active", "onboard_run"]
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2) + "\n"
+    tmp = path.with_name(f".{path.name}.tmp")
+    tmp.write_text(text, encoding="utf-8")
+    tmp.replace(path)
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def compute_reference_content_hash(
+    artifact_paths: dict[str, Path] | Iterable[tuple[str, Path]],
+) -> str:
+    """
+    Stable content hash over named artifact files.
+
+    Files are mixed in sorted basename order as ``name\\0bytes\\0``. Returns ``sha256:<hex>``.
+    """
+    if isinstance(artifact_paths, dict):
+        items = list(artifact_paths.items())
+    else:
+        items = list(artifact_paths)
+    if not items:
+        raise ValueError("artifact_paths must be non-empty")
+    h = hashlib.sha256()
+    for name, path in sorted(items, key=lambda x: x[0]):
+        p = Path(path)
+        if not p.is_file():
+            raise FileNotFoundError(f"Cannot hash missing artifact: {p}")
+        h.update(name.encode("utf-8"))
+        h.update(b"\0")
+        h.update(p.read_bytes())
+        h.update(b"\0")
+    return f"sha256:{h.hexdigest()}"
+
+
+def read_genai_reference_pin(current_root: str | Path) -> dict[str, Any] | None:
+    """Load ``genai_reference_pin.json`` from ``current_root`` if present."""
+    p = Path(current_root) / GENAI_REFERENCE_PIN_BASENAME
+    if not p.is_file():
+        return None
+    data = json.loads(p.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise TypeError(f"Expected JSON object in {p}")
+    return data
+
+
+def resolve_pinned_artifact_files(current_root: str | Path) -> dict[str, Path]:
+    """
+    Map basename -> path for artifacts present under ``current/`` that participate in the hash.
+
+    Requires :data:`REFERENCE_PIN_REQUIRED_ARTIFACTS`. Optional artifacts are included when present.
+    """
+    root = Path(current_root)
+    out: dict[str, Path] = {}
+    for name in REFERENCE_PIN_REQUIRED_ARTIFACTS:
+        p = root / name
+        if not p.is_file():
+            raise FileNotFoundError(
+                f"Pinned reference missing required artifact {name!r} under {root}"
+            )
+        out[name] = p
+    for name in REFERENCE_PIN_OPTIONAL_ARTIFACTS:
+        p = root / name
+        if p.is_file():
+            out[name] = p
+    return out
+
+
+def verify_reference_pin_hash(current_root: str | Path) -> str:
+    """
+    Recompute the content hash for ``current_root`` and compare to ``genai_reference_pin.json``.
+
+    Returns the verified ``content_hash``. Raises ``FileNotFoundError`` / ``ValueError`` on drift.
+    """
+    root = Path(current_root)
+    pin = read_genai_reference_pin(root)
+    if pin is None:
+        raise FileNotFoundError(
+            f"Missing {GENAI_REFERENCE_PIN_BASENAME} under {root}; reference is not pinned"
+        )
+    expected = str(pin.get("content_hash") or "").strip()
+    if not expected:
+        raise ValueError(
+            f"{GENAI_REFERENCE_PIN_BASENAME} missing content_hash at {root}"
+        )
+    artifacts = resolve_pinned_artifact_files(root)
+    # Prefer the pin's artifact list when present so optional files stay consistent with pin time.
+    listed = pin.get("artifacts")
+    if isinstance(listed, list) and listed:
+        names = [str(x) for x in listed]
+        missing = [n for n in names if n not in artifacts]
+        if missing:
+            raise FileNotFoundError(
+                f"Pin lists artifacts missing on disk under {root}: {missing}"
+            )
+        # Extra optional files on disk that were not part of the pin must not affect the hash.
+        artifacts = {n: artifacts[n] for n in names if n in artifacts}
+        for req in REFERENCE_PIN_REQUIRED_ARTIFACTS:
+            if req not in artifacts:
+                raise FileNotFoundError(
+                    f"Pin artifacts omit required {req!r} under {root}"
+                )
+    actual = compute_reference_content_hash(artifacts)
+    if actual != expected:
+        raise ValueError(
+            f"Reference pin hash mismatch under {root}: pin has {expected!r}, "
+            f"disk computes {actual!r}"
+        )
+    return actual
+
+
+def resolve_reference_source_paths(
+    *,
+    catalog: str,
+    source_institution_id: str,
+    source: SourceKind = "active",
+    onboard_run_id: str | None = None,
+) -> dict[str, Path]:
+    """
+    Resolve source artifact paths on the institution silver volume.
+
+    ``active`` — flat ``genai_mapping/active/``.
+    ``onboard_run`` — IA + SMA run trees under ``runs/onboard/<onboard_run_id>/``.
+    """
+    inst = str(source_institution_id).strip()
+    if not inst:
+        raise ValueError("source_institution_id must be non-empty")
+    genai = Path(silver_genai_mapping_root(inst, catalog=catalog))
+
+    if source == "active":
+        active = genai / "active"
+        paths = {
+            "manifest_map.json": active / "manifest_map.json",
+            "transformation_map.json": active / "transformation_map.json",
+            "enriched_schema_contract.json": active / "enriched_schema_contract.json",
+        }
+    elif source == "onboard_run":
+        rid = str(onboard_run_id or "").strip()
+        if not rid:
+            raise ValueError("onboard_run_id is required when source='onboard_run'")
+        ia = genai / "runs" / "onboard" / rid / "identity_agent"
+        sma = genai / "runs" / "onboard" / rid / "schema_mapping_agent"
+        paths = {
+            "manifest_map.json": sma / "manifest_map.json",
+            "transformation_map.json": sma / "transformation_map.json",
+            "enriched_schema_contract.json": ia / "enriched_schema_contract.json",
+        }
+    else:
+        raise ValueError(f"source must be 'active' or 'onboard_run', got {source!r}")
+
+    for name in REFERENCE_PIN_REQUIRED_ARTIFACTS:
+        if not paths[name].is_file():
+            raise FileNotFoundError(
+                f"Cannot pin missing required source artifact {name!r}: {paths[name]}"
+            )
+    return {k: v for k, v in paths.items() if v.is_file()}
+
+
+def _history_dirname(*, pinned_at: str, content_hash: str) -> str:
+    """Folder name under ``references/<id>/`` for an immutable history snapshot."""
+    day = pinned_at[:10].replace("-", "") if pinned_at else "unknown"
+    digest = content_hash.removeprefix("sha256:")[:12]
+    return f"v{day}_{digest}"
+
+
+def pin_reference_snapshot(
+    *,
+    catalog: str,
+    reference_id: str,
+    source_institution_id: str,
+    pinned_by: str,
+    source: SourceKind = "active",
+    onboard_run_id: str | None = None,
+    archetype: str | None = None,
+    pipeline_version: str | None = None,
+    write_history_copy: bool = True,
+) -> dict[str, Any]:
+    """
+    Copy source artifacts into ``references/<reference_id>/current/`` and write pin metadata.
+
+    Returns the pin payload (also written as ``genai_reference_pin.json``). Does **not** write
+    the UC ``reference_pins`` table — callers use :func:`upsert_reference_pin_row` for that.
+    """
+    ref = str(reference_id).strip()
+    by = str(pinned_by).strip()
+    if not ref:
+        raise ValueError("reference_id must be non-empty")
+    if not by:
+        raise ValueError("pinned_by must be non-empty")
+
+    source_paths = resolve_reference_source_paths(
+        catalog=catalog,
+        source_institution_id=source_institution_id,
+        source=source,
+        onboard_run_id=onboard_run_id,
+    )
+
+    # Provenance defaults from active registry when pinning from active/.
+    resolved_run_id = str(onboard_run_id or "").strip() or None
+    resolved_pipeline = str(pipeline_version or "").strip() or None
+    if source == "active":
+        active_root = (
+            Path(silver_genai_mapping_root(source_institution_id, catalog=catalog))
+            / "active"
+        )
+        reg = read_genai_active_registry(active_root)
+        if reg:
+            if not resolved_run_id:
+                rid = str(reg.get("onboard_run_id") or "").strip()
+                resolved_run_id = rid or None
+            if not resolved_pipeline:
+                pver = str(reg.get("pipeline_version") or "").strip()
+                resolved_pipeline = pver or None
+
+    content_hash = compute_reference_content_hash(source_paths)
+    pinned_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    artifact_names = sorted(source_paths.keys())
+
+    current = Path(genai_reference_current_root(ref, catalog=catalog))
+    current.mkdir(parents=True, exist_ok=True)
+
+    for name, src in source_paths.items():
+        dst = current / name
+        shutil.copy2(src, dst)
+        LOGGER.info("Pinned %s -> %s", src, dst)
+
+    payload: dict[str, Any] = {
+        "schema_version": _REFERENCE_PIN_SCHEMA_VERSION,
+        "reference_id": ref,
+        "source_institution_id": str(source_institution_id).strip(),
+        "pinned_at": pinned_at,
+        "pinned_by": by,
+        "content_hash": content_hash,
+        "artifacts": artifact_names,
+        "source": source,
+        "uc_catalog": str(catalog).strip(),
+    }
+    if resolved_run_id:
+        payload["source_onboard_run_id"] = resolved_run_id
+    if resolved_pipeline:
+        payload["pipeline_version"] = resolved_pipeline
+    if archetype and str(archetype).strip():
+        payload["archetype"] = str(archetype).strip()
+
+    pin_path = current / GENAI_REFERENCE_PIN_BASENAME
+    _atomic_write_json(pin_path, payload)
+    LOGGER.info("Wrote %s (content_hash=%r)", pin_path, content_hash)
+
+    # Confirm round-trip hash matches what we just wrote.
+    verify_reference_pin_hash(current)
+
+    if write_history_copy:
+        hist = current.parent / _history_dirname(
+            pinned_at=pinned_at, content_hash=content_hash
+        )
+        if hist.exists():
+            shutil.rmtree(hist)
+        shutil.copytree(current, hist)
+        LOGGER.info("Wrote history snapshot %s", hist)
+
+    return payload
+
+
+def upsert_reference_pin_row(
+    catalog: str,
+    pin: dict[str, Any],
+    *,
+    spark: Any | None = None,
+) -> None:
+    """
+    Mark prior ``active`` rows for this ``reference_id`` as ``superseded`` and insert the new pin.
+
+    Ensures state tables (including ``reference_pins``) exist via :func:`create_state_tables`.
+    """
+    from edvise.genai.mapping.state._sql import (
+        REFERENCE_PINS,
+        get_spark_session,
+        lit,
+        qualified_table,
+    )
+    from edvise.genai.mapping.state.table_setup import create_state_tables
+
+    c = str(catalog).strip()
+    ref = str(pin.get("reference_id") or "").strip()
+    content_hash = str(pin.get("content_hash") or "").strip()
+    if not c or not ref or not content_hash:
+        raise ValueError("catalog, pin.reference_id, and pin.content_hash are required")
+
+    spark = spark if spark is not None else get_spark_session()
+    if spark is None:
+        raise RuntimeError(
+            "No active Spark session; cannot write reference_pins (pass spark= or run on Databricks)"
+        )
+
+    create_state_tables(c, spark=spark)
+    t = qualified_table(c, REFERENCE_PINS)
+
+    spark.sql(
+        f"""
+        UPDATE {t}
+        SET status = 'superseded'
+        WHERE reference_id = {lit(ref)}
+          AND status = 'active'
+        """
+    )
+
+    artifacts = pin.get("artifacts") or []
+    if isinstance(artifacts, (list, tuple)):
+        artifacts_json = json.dumps(list(artifacts))
+    else:
+        artifacts_json = json.dumps([])
+
+    pin_path = genai_reference_current_root(ref, catalog=c)
+    archetype = str(pin.get("archetype") or "").strip()
+    pipeline_version = str(pin.get("pipeline_version") or "").strip()
+    pinned_by = str(pin.get("pinned_by") or "").strip()
+    source_onboard_run_id = str(pin.get("source_onboard_run_id") or "").strip()
+    source_institution_id = str(pin.get("source_institution_id") or "").strip()
+    pinned_at = str(pin.get("pinned_at") or "").strip()
+
+    spark.sql(
+        f"""
+        INSERT INTO {t} (
+          reference_id,
+          archetype,
+          pipeline_version,
+          content_hash,
+          pinned_at,
+          pinned_by,
+          source_onboard_run_id,
+          source_institution_id,
+          status,
+          uc_catalog,
+          artifacts,
+          pin_path
+        ) VALUES (
+          {lit(ref)},
+          {lit(archetype) if archetype else "NULL"},
+          {lit(pipeline_version) if pipeline_version else "NULL"},
+          {lit(content_hash)},
+          {f"CAST({lit(pinned_at)} AS TIMESTAMP)" if pinned_at else "current_timestamp()"},
+          {lit(pinned_by) if pinned_by else "NULL"},
+          {lit(source_onboard_run_id) if source_onboard_run_id else "NULL"},
+          {lit(source_institution_id) if source_institution_id else "NULL"},
+          {lit("active")},
+          {lit(c)},
+          {lit(artifacts_json)},
+          {lit(pin_path)}
+        )
+        """
+    )
+    LOGGER.info(
+        "Upserted reference_pins row reference_id=%r content_hash=%r", ref, content_hash
+    )
+
+
+def active_reference_pin_row(
+    catalog: str,
+    reference_id: str,
+    *,
+    spark: Any | None = None,
+) -> dict[str, Any] | None:
+    """Return the ``status='active'`` registry row for ``reference_id``, or None."""
+    from edvise.genai.mapping.state._sql import (
+        REFERENCE_PINS,
+        get_spark_session,
+        lit,
+        qualified_table,
+    )
+
+    c = str(catalog).strip()
+    ref = str(reference_id).strip()
+    if not c or not ref:
+        raise ValueError("catalog and reference_id must be non-empty")
+
+    spark = spark if spark is not None else get_spark_session()
+    if spark is None:
+        return None
+
+    t = qualified_table(c, REFERENCE_PINS)
+    rows = spark.sql(
+        f"""
+        SELECT
+          reference_id,
+          archetype,
+          pipeline_version,
+          content_hash,
+          pinned_at,
+          pinned_by,
+          source_onboard_run_id,
+          source_institution_id,
+          status,
+          uc_catalog,
+          artifacts,
+          pin_path
+        FROM {t}
+        WHERE reference_id = {lit(ref)}
+          AND status = 'active'
+        ORDER BY pinned_at DESC
+        LIMIT 1
+        """
+    ).collect()
+    if not rows:
+        return None
+    row = rows[0]
+    if hasattr(row, "asDict"):
+        return dict(row.asDict())  # type: ignore[attr-defined]
+    return {
+        "reference_id": row["reference_id"],
+        "archetype": row["archetype"],
+        "pipeline_version": row["pipeline_version"],
+        "content_hash": row["content_hash"],
+        "pinned_at": row["pinned_at"],
+        "pinned_by": row["pinned_by"],
+        "source_onboard_run_id": row["source_onboard_run_id"],
+        "source_institution_id": row["source_institution_id"],
+        "status": row["status"],
+        "uc_catalog": row["uc_catalog"],
+        "artifacts": row["artifacts"],
+        "pin_path": row["pin_path"],
+    }

--- a/src/edvise/genai/mapping/shared/reference_pin.py
+++ b/src/edvise/genai/mapping/shared/reference_pin.py
@@ -9,11 +9,11 @@ explicit copy into::
 plus ``genai_reference_pin.json`` (local hash metadata) and a row in
 ``{catalog}.genai_mapping.reference_pins``.
 
-Two job modes:
+Two job modes (selected by ``catalog``, not a CLI flag):
 
-* ``publish`` — copy from local ``active/`` (canonical catalog, ``dev_sst_02``).
-* ``pull`` — copy ``references/<id>/current/`` from ``source_catalog`` into this catalog
-  (replica, e.g. ``staging_sst_01``); does not read local ``active/`` (parity).
+* ``publish`` — ``catalog=dev_sst_02``: copy from local ``active/``.
+* ``pull`` — ``catalog=staging_sst_01``: copy ``references/<id>/current/`` from
+  ``dev_sst_02``; does not read local ``active/`` (parity).
 """
 
 from __future__ import annotations
@@ -51,8 +51,27 @@ REFERENCE_PIN_OPTIONAL_ARTIFACTS: tuple[str, ...] = ("enriched_schema_contract.j
 SourceKind = Literal["active", "onboard_run"]
 PinMode = Literal["publish", "pull"]
 
-# Canonical catalog for gold references; pull mode defaults to this as source.
+# Canonical catalog for gold references (publish writes here; pull reads from here).
 DEFAULT_CANONICAL_REFERENCE_CATALOG: str = "dev_sst_02"
+# Replica catalog that pulls from the canonical catalog.
+DEFAULT_REPLICA_REFERENCE_CATALOG: str = "staging_sst_01"
+
+
+def resolve_pin_mode(catalog: str) -> PinMode:
+    """
+    Map UC catalog to pin action.
+
+    ``dev_sst_02`` → publish; ``staging_sst_01`` → pull. Any other catalog is rejected.
+    """
+    c = str(catalog).strip()
+    if c == DEFAULT_CANONICAL_REFERENCE_CATALOG:
+        return "publish"
+    if c == DEFAULT_REPLICA_REFERENCE_CATALOG:
+        return "pull"
+    raise ValueError(
+        f"catalog must be {DEFAULT_CANONICAL_REFERENCE_CATALOG!r} (publish) or "
+        f"{DEFAULT_REPLICA_REFERENCE_CATALOG!r} (pull); got {c!r}"
+    )
 
 
 def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:

--- a/src/edvise/genai/mapping/shared/reference_pin.py
+++ b/src/edvise/genai/mapping/shared/reference_pin.py
@@ -8,6 +8,12 @@ explicit copy into::
 
 plus ``genai_reference_pin.json`` (local hash metadata) and a row in
 ``{catalog}.genai_mapping.reference_pins``.
+
+Two job modes:
+
+* ``publish`` — copy from local ``active/`` (canonical catalog, e.g. staging).
+* ``pull`` — copy ``references/<id>/current/`` from ``source_catalog`` into this catalog;
+  does not read local ``active/`` (replica parity).
 """
 
 from __future__ import annotations
@@ -43,6 +49,10 @@ REFERENCE_PIN_REQUIRED_ARTIFACTS: tuple[str, ...] = (
 REFERENCE_PIN_OPTIONAL_ARTIFACTS: tuple[str, ...] = ("enriched_schema_contract.json",)
 
 SourceKind = Literal["active", "onboard_run"]
+PinMode = Literal["publish", "pull"]
+
+# Canonical catalog for gold references; pull mode defaults to this as source.
+DEFAULT_CANONICAL_REFERENCE_CATALOG: str = "staging_sst_01"
 
 
 def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
@@ -51,10 +61,6 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     tmp = path.with_name(f".{path.name}.tmp")
     tmp.write_text(text, encoding="utf-8")
     tmp.replace(path)
-
-
-def _sha256_bytes(data: bytes) -> str:
-    return hashlib.sha256(data).hexdigest()
 
 
 def compute_reference_content_hash(
@@ -294,6 +300,102 @@ def pin_reference_snapshot(
         shutil.copytree(current, hist)
         LOGGER.info("Wrote history snapshot %s", hist)
 
+    return payload
+
+
+def pull_reference_snapshot(
+    *,
+    catalog: str,
+    reference_id: str,
+    source_catalog: str,
+    write_history_copy: bool = True,
+) -> dict[str, Any]:
+    """
+    Copy a pinned reference from ``source_catalog`` into ``catalog`` (replica).
+
+    Does **not** read local ``active/`` — that is intentional so divergent school
+    active state cannot overwrite the gold few-shot library.
+
+    Requires readable
+    ``/Volumes/<source_catalog>/genai_mapping/references/<reference_id>/current/``.
+    Verifies the source pin hash, copies bytes, re-verifies on the destination, and
+    returns the destination pin payload (with ``pulled_from_catalog`` set).
+    """
+    dest_cat = str(catalog).strip()
+    src_cat = str(source_catalog).strip()
+    ref = str(reference_id).strip()
+    if not dest_cat or not src_cat or not ref:
+        raise ValueError("catalog, source_catalog, and reference_id must be non-empty")
+    if dest_cat == src_cat:
+        raise ValueError(
+            f"pull mode requires source_catalog != catalog (both are {dest_cat!r})"
+        )
+
+    source_current = Path(genai_reference_current_root(ref, catalog=src_cat))
+    if not source_current.is_dir():
+        raise FileNotFoundError(
+            f"Cannot pull reference {ref!r}: source current/ missing at {source_current}. "
+            f"Publish on {src_cat} first, and ensure this job can read that catalog's volumes."
+        )
+
+    source_hash = verify_reference_pin_hash(source_current)
+    source_pin = read_genai_reference_pin(source_current)
+    if source_pin is None:
+        raise FileNotFoundError(
+            f"Missing {GENAI_REFERENCE_PIN_BASENAME} under {source_current}"
+        )
+
+    dest_current = Path(genai_reference_current_root(ref, catalog=dest_cat))
+    dest_current.mkdir(parents=True, exist_ok=True)
+
+    # Replace destination current/ contents with source artifacts + pin sidecar.
+    for existing in dest_current.iterdir():
+        if existing.is_file():
+            existing.unlink()
+        elif existing.is_dir():
+            shutil.rmtree(existing)
+
+    for src in source_current.iterdir():
+        if not src.is_file():
+            continue
+        shutil.copy2(src, dest_current / src.name)
+        LOGGER.info("Pulled %s -> %s", src, dest_current / src.name)
+
+    pulled_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    payload = dict(source_pin)
+    payload["uc_catalog"] = dest_cat
+    payload["pulled_from_catalog"] = src_cat
+    payload["pulled_at"] = pulled_at
+    # Keep original content_hash / source_onboard_run_id / artifacts from canonical pin.
+    if str(payload.get("content_hash") or "").strip() != source_hash:
+        payload["content_hash"] = source_hash
+
+    pin_path = dest_current / GENAI_REFERENCE_PIN_BASENAME
+    _atomic_write_json(pin_path, payload)
+
+    dest_hash = verify_reference_pin_hash(dest_current)
+    if dest_hash != source_hash:
+        raise ValueError(
+            f"Pull hash mismatch for {ref!r}: source {source_hash!r} vs dest {dest_hash!r}"
+        )
+
+    if write_history_copy:
+        hist = dest_current.parent / _history_dirname(
+            pinned_at=str(payload.get("pinned_at") or pulled_at),
+            content_hash=dest_hash,
+        )
+        if hist.exists():
+            shutil.rmtree(hist)
+        shutil.copytree(dest_current, hist)
+        LOGGER.info("Wrote history snapshot %s", hist)
+
+    LOGGER.info(
+        "Pulled reference_id=%r %s -> %s content_hash=%r",
+        ref,
+        src_cat,
+        dest_cat,
+        dest_hash,
+    )
     return payload
 
 

--- a/src/edvise/genai/mapping/shared/volume_paths.py
+++ b/src/edvise/genai/mapping/shared/volume_paths.py
@@ -43,6 +43,34 @@ def silver_genai_mapping_root(institution_id: str, *, catalog: str) -> str:
     return f"{_uc_volume_path(institution_id, catalog=catalog, tier='silver')}/genai_mapping"
 
 
+def genai_mapping_schema_volume_root(
+    *, catalog: str, volume: str = "references"
+) -> str:
+    """
+    Shared platform volume under the ``genai_mapping`` UC schema (not per-institution silver).
+
+    Path: ``/Volumes/<catalog>/genai_mapping/<volume>``.
+    """
+    cat = _require_uc_catalog(catalog)
+    vol = str(volume).strip()
+    if not vol:
+        raise ValueError("volume must be non-empty")
+    return f"/Volumes/{cat}/genai_mapping/{vol}"
+
+
+def genai_reference_root(reference_id: str, *, catalog: str) -> str:
+    """``…/genai_mapping/references/<reference_id>`` on the shared references volume."""
+    ref = str(reference_id).strip()
+    if not ref:
+        raise ValueError("reference_id must be non-empty")
+    return f"{genai_mapping_schema_volume_root(catalog=catalog, volume='references')}/{ref}"
+
+
+def genai_reference_current_root(reference_id: str, *, catalog: str) -> str:
+    """Pinned few-shot artifacts: ``…/references/<reference_id>/current``."""
+    return f"{genai_reference_root(reference_id, catalog=catalog)}/current"
+
+
 def resolve_genai_inputs_toml_path(
     institution_id: str,
     *,

--- a/src/edvise/genai/mapping/state/_sql.py
+++ b/src/edvise/genai/mapping/state/_sql.py
@@ -11,6 +11,8 @@ GENAI_MAPPING_SCHEMA: str = "genai_mapping"
 PIPELINE_RUNS: str = "pipeline_runs"
 PIPELINE_PHASES: str = "pipeline_phases"
 HITL_REVIEWS: str = "hitl_reviews"
+REFERENCE_PINS: str = "reference_pins"
+REFERENCES_VOLUME: str = "references"
 
 
 def get_spark_session() -> Any:

--- a/src/edvise/genai/mapping/state/table_setup.py
+++ b/src/edvise/genai/mapping/state/table_setup.py
@@ -15,6 +15,8 @@ from edvise.genai.mapping.state._sql import (
     HITL_REVIEWS,
     PIPELINE_PHASES,
     PIPELINE_RUNS,
+    REFERENCE_PINS,
+    REFERENCES_VOLUME,
     get_spark_session,
     qualified_schema,
     qualified_table,
@@ -144,6 +146,10 @@ def create_state_tables(catalog: str, spark: Any | None = None) -> None:
     * ``pipeline_runs`` — top-level run tracking
     * ``pipeline_phases`` — phase transition audit log
     * ``hitl_reviews`` — HITL artifact path + review status
+    * ``reference_pins`` — gold few-shot pin metadata + content hashes
+
+    Also best-effort creates the managed volume ``genai_mapping.references`` used for
+    pinned artifact files (``/Volumes/<catalog>/genai_mapping/references/``).
 
     Pass ``spark`` when the caller already holds the active session (e.g. tests that
     monkeypatch :func:`edvise.genai.mapping.state._sql.get_spark_session`).
@@ -160,9 +166,23 @@ def create_state_tables(catalog: str, spark: Any | None = None) -> None:
     c = str(catalog).strip()
     spark.sql(f"CREATE SCHEMA IF NOT EXISTS {qualified_schema(c)}")
 
+    # Shared few-shot library volume (sibling of state tables under genai_mapping).
+    try:
+        spark.sql(
+            f"CREATE VOLUME IF NOT EXISTS {qualified_schema(c)}.`{REFERENCES_VOLUME}`"
+        )
+    except Exception as e:  # noqa: BLE001 — volume DDL may be unavailable off Databricks
+        LOGGER.warning(
+            "Could not ensure volume %s.%s (%s); create it manually if pinning fails",
+            qualified_schema(c),
+            REFERENCES_VOLUME,
+            e,
+        )
+
     pr = qualified_table(c, PIPELINE_RUNS)
     pp = qualified_table(c, PIPELINE_PHASES)
     hr = qualified_table(c, HITL_REVIEWS)
+    rp = qualified_table(c, REFERENCE_PINS)
 
     spark.sql(
         f"""
@@ -207,6 +227,24 @@ def create_state_tables(catalog: str, spark: Any | None = None) -> None:
           status STRING,
           reviewer STRING,
           reviewed_at TIMESTAMP
+        ) USING DELTA
+        """
+    )
+    spark.sql(
+        f"""
+        CREATE TABLE IF NOT EXISTS {rp} (
+          reference_id STRING,
+          archetype STRING,
+          pipeline_version STRING,
+          content_hash STRING,
+          pinned_at TIMESTAMP,
+          pinned_by STRING,
+          source_onboard_run_id STRING,
+          source_institution_id STRING,
+          status STRING,
+          uc_catalog STRING,
+          artifacts STRING,
+          pin_path STRING
         ) USING DELTA
         """
     )

--- a/tests/genai/mapping/shared/test_reference_pin.py
+++ b/tests/genai/mapping/shared/test_reference_pin.py
@@ -198,8 +198,8 @@ def test_upsert_reference_pin_row_sql(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_pull_reference_snapshot_copies_bytes_not_active(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    src_cat = "staging_sst_01"
-    dest_cat = "dev_sst_02"
+    src_cat = "dev_sst_02"
+    dest_cat = "staging_sst_01"
     ref = "demo_col"
     volumes = tmp_path / "Volumes"
     _patch_volume_roots(monkeypatch, volumes)

--- a/tests/genai/mapping/shared/test_reference_pin.py
+++ b/tests/genai/mapping/shared/test_reference_pin.py
@@ -57,7 +57,7 @@ def _seed_active(
     institution_id: str,
     with_registry: bool = True,
 ) -> Path:
-    """Create a silver active/ tree under tmp_path by patching volume roots via monkeypatch later."""
+    """Create a silver active/ tree under tmp_path (volume roots patched in tests)."""
     active = (
         tmp_path
         / "Volumes"
@@ -88,14 +88,7 @@ def _seed_active(
     return active
 
 
-def test_pin_reference_snapshot_from_active(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    catalog = "dev_cat"
-    inst = "demo_col"
-    ref = "ref_demo_01"
-
-    volumes = tmp_path / "Volumes"
+def _patch_volume_roots(monkeypatch: pytest.MonkeyPatch, volumes: Path) -> None:
     monkeypatch.setattr(
         rp,
         "silver_genai_mapping_root",
@@ -120,16 +113,17 @@ def test_pin_reference_snapshot_from_active(
         ),
     )
 
-    _seed_active(tmp_path, catalog=catalog, institution_id=inst)
 
-    pin = rp.pin_reference_snapshot(
-        catalog=catalog,
-        reference_id=ref,
-        source_institution_id=inst,
-        pinned_by="tester",
-        source="active",
-        archetype="cc_student_term",
-    )
+def test_pin_reference_snapshot_from_active(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    catalog = "dev_cat"
+    ref = "demo_col"
+    volumes = tmp_path / "Volumes"
+    _patch_volume_roots(monkeypatch, volumes)
+    _seed_active(tmp_path, catalog=catalog, institution_id=ref)
+
+    pin = rp.pin_reference_snapshot(catalog=catalog, reference_id=ref)
 
     current = Path(rp.genai_reference_current_root(ref, catalog=catalog))
     assert (current / "manifest_map.json").read_text(encoding="utf-8") == '{"m": 1}'
@@ -138,12 +132,14 @@ def test_pin_reference_snapshot_from_active(
     ) == '{"t": 1}'
     assert (current / "enriched_schema_contract.json").is_file()
     assert pin["content_hash"].startswith("sha256:")
+    assert pin["reference_id"] == ref
+    assert pin["source_institution_id"] == ref
     assert pin["source_onboard_run_id"] == "school_20260101_1"
     assert pin["pipeline_version"] == "abc123"
-    assert pin["archetype"] == "cc_student_term"
+    assert "pinned_by" not in pin
+    assert "archetype" not in pin
     assert rp.verify_reference_pin_hash(current) == pin["content_hash"]
 
-    # History snapshot exists
     hist_dirs = [
         p for p in current.parent.iterdir() if p.is_dir() and p.name.startswith("v")
     ]
@@ -155,98 +151,17 @@ def test_verify_reference_pin_hash_detects_drift(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     catalog = "dev_cat"
-    inst = "demo_col"
-    ref = "ref_demo_02"
+    ref = "demo_col"
     volumes = tmp_path / "Volumes"
-    monkeypatch.setattr(
-        rp,
-        "silver_genai_mapping_root",
-        lambda institution_id, *, catalog: str(
-            volumes
-            / catalog
-            / f"{institution_id}_silver"
-            / "silver_volume"
-            / "genai_mapping"
-        ),
-    )
-    monkeypatch.setattr(
-        rp,
-        "genai_reference_current_root",
-        lambda reference_id, *, catalog: str(
-            volumes
-            / catalog
-            / "genai_mapping"
-            / "references"
-            / reference_id
-            / "current"
-        ),
-    )
-    _seed_active(tmp_path, catalog=catalog, institution_id=inst)
+    _patch_volume_roots(monkeypatch, volumes)
+    _seed_active(tmp_path, catalog=catalog, institution_id=ref)
     rp.pin_reference_snapshot(
-        catalog=catalog,
-        reference_id=ref,
-        source_institution_id=inst,
-        pinned_by="tester",
-        write_history_copy=False,
+        catalog=catalog, reference_id=ref, write_history_copy=False
     )
     current = Path(rp.genai_reference_current_root(ref, catalog=catalog))
     (current / "manifest_map.json").write_text('{"m": "tampered"}', encoding="utf-8")
     with pytest.raises(ValueError, match="hash mismatch"):
         rp.verify_reference_pin_hash(current)
-
-
-def test_pin_from_onboard_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    catalog = "dev_cat"
-    inst = "demo_col"
-    ref = "ref_demo_03"
-    run_id = "demo_20260102_1"
-    volumes = tmp_path / "Volumes"
-    monkeypatch.setattr(
-        rp,
-        "silver_genai_mapping_root",
-        lambda institution_id, *, catalog: str(
-            volumes
-            / catalog
-            / f"{institution_id}_silver"
-            / "silver_volume"
-            / "genai_mapping"
-        ),
-    )
-    monkeypatch.setattr(
-        rp,
-        "genai_reference_current_root",
-        lambda reference_id, *, catalog: str(
-            volumes
-            / catalog
-            / "genai_mapping"
-            / "references"
-            / reference_id
-            / "current"
-        ),
-    )
-    genai = volumes / catalog / f"{inst}_silver" / "silver_volume" / "genai_mapping"
-    ia = genai / "runs" / "onboard" / run_id / "identity_agent"
-    sma = genai / "runs" / "onboard" / run_id / "schema_mapping_agent"
-    ia.mkdir(parents=True)
-    sma.mkdir(parents=True)
-    (sma / "manifest_map.json").write_text('{"m": 9}', encoding="utf-8")
-    (sma / "transformation_map.json").write_text('{"t": 9}', encoding="utf-8")
-    (ia / "enriched_schema_contract.json").write_text('{"c": 9}', encoding="utf-8")
-
-    pin = rp.pin_reference_snapshot(
-        catalog=catalog,
-        reference_id=ref,
-        source_institution_id=inst,
-        pinned_by="tester",
-        source="onboard_run",
-        onboard_run_id=run_id,
-        pipeline_version="deadbeef",
-        write_history_copy=False,
-    )
-    assert pin["source_onboard_run_id"] == run_id
-    assert pin["pipeline_version"] == "deadbeef"
-    current = Path(rp.genai_reference_current_root(ref, catalog=catalog))
-    assert (current / "manifest_map.json").read_text(encoding="utf-8") == '{"m": 9}'
 
 
 def test_upsert_reference_pin_row_sql(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -263,20 +178,18 @@ def test_upsert_reference_pin_row_sql(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda catalog, spark=None: None,
     )
     pin = {
-        "reference_id": "ref_x",
+        "reference_id": "school_a",
         "content_hash": "sha256:abc",
-        "pinned_by": "alice",
         "pinned_at": "2026-06-22T12:00:00Z",
         "source_institution_id": "school_a",
         "source_onboard_run_id": "run_1",
         "pipeline_version": "v1",
-        "archetype": "cc",
         "artifacts": ["manifest_map.json", "transformation_map.json"],
     }
     rp.upsert_reference_pin_row("my_cat", pin, spark=fake)
     assert any("UPDATE" in s and "superseded" in s for s in fake.statements)
     insert = next(s for s in fake.statements if "INSERT INTO" in s)
     assert "reference_pins" in insert
-    assert "ref_x" in insert
+    assert "school_a" in insert
     assert "sha256:abc" in insert
     assert "active" in insert

--- a/tests/genai/mapping/shared/test_reference_pin.py
+++ b/tests/genai/mapping/shared/test_reference_pin.py
@@ -193,3 +193,60 @@ def test_upsert_reference_pin_row_sql(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "school_a" in insert
     assert "sha256:abc" in insert
     assert "active" in insert
+
+
+def test_pull_reference_snapshot_copies_bytes_not_active(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    src_cat = "staging_sst_01"
+    dest_cat = "dev_sst_02"
+    ref = "demo_col"
+    volumes = tmp_path / "Volumes"
+    _patch_volume_roots(monkeypatch, volumes)
+
+    # Publish on staging from active/
+    _seed_active(tmp_path, catalog=src_cat, institution_id=ref)
+    published = rp.pin_reference_snapshot(
+        catalog=src_cat, reference_id=ref, write_history_copy=False
+    )
+
+    # Divergent active on dest must not affect pull
+    dest_active = (
+        volumes
+        / dest_cat
+        / f"{ref}_silver"
+        / "silver_volume"
+        / "genai_mapping"
+        / "active"
+    )
+    dest_active.mkdir(parents=True)
+    (dest_active / "manifest_map.json").write_text('{"m": "WRONG"}', encoding="utf-8")
+    (dest_active / "transformation_map.json").write_text(
+        '{"t": "WRONG"}', encoding="utf-8"
+    )
+
+    pulled = rp.pull_reference_snapshot(
+        catalog=dest_cat,
+        reference_id=ref,
+        source_catalog=src_cat,
+        write_history_copy=False,
+    )
+
+    dest_current = Path(rp.genai_reference_current_root(ref, catalog=dest_cat))
+    assert (dest_current / "manifest_map.json").read_text(
+        encoding="utf-8"
+    ) == '{"m": 1}'
+    assert pulled["content_hash"] == published["content_hash"]
+    assert pulled["pulled_from_catalog"] == src_cat
+    assert pulled["uc_catalog"] == dest_cat
+    assert pulled["source_onboard_run_id"] == "school_20260101_1"
+    assert rp.verify_reference_pin_hash(dest_current) == published["content_hash"]
+
+
+def test_pull_rejects_same_catalog() -> None:
+    with pytest.raises(ValueError, match="source_catalog != catalog"):
+        rp.pull_reference_snapshot(
+            catalog="dev_sst_02",
+            reference_id="x",
+            source_catalog="dev_sst_02",
+        )

--- a/tests/genai/mapping/shared/test_reference_pin.py
+++ b/tests/genai/mapping/shared/test_reference_pin.py
@@ -250,3 +250,10 @@ def test_pull_rejects_same_catalog() -> None:
             reference_id="x",
             source_catalog="dev_sst_02",
         )
+
+
+def test_resolve_pin_mode() -> None:
+    assert rp.resolve_pin_mode("dev_sst_02") == "publish"
+    assert rp.resolve_pin_mode("staging_sst_01") == "pull"
+    with pytest.raises(ValueError, match="catalog must be"):
+        rp.resolve_pin_mode("other_cat")

--- a/tests/genai/mapping/shared/test_reference_pin.py
+++ b/tests/genai/mapping/shared/test_reference_pin.py
@@ -1,0 +1,282 @@
+"""Tests for :mod:`edvise.genai.mapping.shared.reference_pin` and reference volume paths."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from edvise.genai.mapping.shared import reference_pin as rp
+from edvise.genai.mapping.shared.volume_paths import (
+    genai_mapping_schema_volume_root,
+    genai_reference_current_root,
+    genai_reference_root,
+)
+
+
+def test_genai_reference_volume_paths() -> None:
+    assert (
+        genai_mapping_schema_volume_root(catalog="dev_sst_02")
+        == "/Volumes/dev_sst_02/genai_mapping/references"
+    )
+    assert (
+        genai_reference_root("ref_cc_01", catalog="dev_sst_02")
+        == "/Volumes/dev_sst_02/genai_mapping/references/ref_cc_01"
+    )
+    assert (
+        genai_reference_current_root("ref_cc_01", catalog="dev_sst_02")
+        == "/Volumes/dev_sst_02/genai_mapping/references/ref_cc_01/current"
+    )
+
+
+def test_compute_reference_content_hash_stable(tmp_path: Path) -> None:
+    a = tmp_path / "manifest_map.json"
+    b = tmp_path / "transformation_map.json"
+    a.write_text('{"m": 1}\n', encoding="utf-8")
+    b.write_text('{"t": 1}\n', encoding="utf-8")
+    h1 = rp.compute_reference_content_hash(
+        {"transformation_map.json": b, "manifest_map.json": a}
+    )
+    h2 = rp.compute_reference_content_hash(
+        {"manifest_map.json": a, "transformation_map.json": b}
+    )
+    assert h1 == h2
+    assert h1.startswith("sha256:")
+    b.write_text('{"t": 2}\n', encoding="utf-8")
+    h3 = rp.compute_reference_content_hash(
+        {"manifest_map.json": a, "transformation_map.json": b}
+    )
+    assert h3 != h1
+
+
+def _seed_active(
+    tmp_path: Path,
+    *,
+    catalog: str,
+    institution_id: str,
+    with_registry: bool = True,
+) -> Path:
+    """Create a silver active/ tree under tmp_path by patching volume roots via monkeypatch later."""
+    active = (
+        tmp_path
+        / "Volumes"
+        / catalog
+        / f"{institution_id}_silver"
+        / "silver_volume"
+        / "genai_mapping"
+        / "active"
+    )
+    active.mkdir(parents=True)
+    (active / "manifest_map.json").write_text('{"m": 1}', encoding="utf-8")
+    (active / "transformation_map.json").write_text('{"t": 1}', encoding="utf-8")
+    (active / "enriched_schema_contract.json").write_text('{"c": 1}', encoding="utf-8")
+    if with_registry:
+        (active / "genai_active_registry.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "onboard_run_id": "school_20260101_1",
+                    "institution_id": institution_id,
+                    "pipeline_version": "abc123",
+                    "promoted_at": "2026-01-01T00:00:00Z",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    return active
+
+
+def test_pin_reference_snapshot_from_active(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    catalog = "dev_cat"
+    inst = "demo_col"
+    ref = "ref_demo_01"
+
+    volumes = tmp_path / "Volumes"
+    monkeypatch.setattr(
+        rp,
+        "silver_genai_mapping_root",
+        lambda institution_id, *, catalog: str(
+            volumes
+            / catalog
+            / f"{institution_id}_silver"
+            / "silver_volume"
+            / "genai_mapping"
+        ),
+    )
+    monkeypatch.setattr(
+        rp,
+        "genai_reference_current_root",
+        lambda reference_id, *, catalog: str(
+            volumes
+            / catalog
+            / "genai_mapping"
+            / "references"
+            / reference_id
+            / "current"
+        ),
+    )
+
+    _seed_active(tmp_path, catalog=catalog, institution_id=inst)
+
+    pin = rp.pin_reference_snapshot(
+        catalog=catalog,
+        reference_id=ref,
+        source_institution_id=inst,
+        pinned_by="tester",
+        source="active",
+        archetype="cc_student_term",
+    )
+
+    current = Path(rp.genai_reference_current_root(ref, catalog=catalog))
+    assert (current / "manifest_map.json").read_text(encoding="utf-8") == '{"m": 1}'
+    assert (current / "transformation_map.json").read_text(
+        encoding="utf-8"
+    ) == '{"t": 1}'
+    assert (current / "enriched_schema_contract.json").is_file()
+    assert pin["content_hash"].startswith("sha256:")
+    assert pin["source_onboard_run_id"] == "school_20260101_1"
+    assert pin["pipeline_version"] == "abc123"
+    assert pin["archetype"] == "cc_student_term"
+    assert rp.verify_reference_pin_hash(current) == pin["content_hash"]
+
+    # History snapshot exists
+    hist_dirs = [
+        p for p in current.parent.iterdir() if p.is_dir() and p.name.startswith("v")
+    ]
+    assert len(hist_dirs) == 1
+    assert (hist_dirs[0] / rp.GENAI_REFERENCE_PIN_BASENAME).is_file()
+
+
+def test_verify_reference_pin_hash_detects_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    catalog = "dev_cat"
+    inst = "demo_col"
+    ref = "ref_demo_02"
+    volumes = tmp_path / "Volumes"
+    monkeypatch.setattr(
+        rp,
+        "silver_genai_mapping_root",
+        lambda institution_id, *, catalog: str(
+            volumes
+            / catalog
+            / f"{institution_id}_silver"
+            / "silver_volume"
+            / "genai_mapping"
+        ),
+    )
+    monkeypatch.setattr(
+        rp,
+        "genai_reference_current_root",
+        lambda reference_id, *, catalog: str(
+            volumes
+            / catalog
+            / "genai_mapping"
+            / "references"
+            / reference_id
+            / "current"
+        ),
+    )
+    _seed_active(tmp_path, catalog=catalog, institution_id=inst)
+    rp.pin_reference_snapshot(
+        catalog=catalog,
+        reference_id=ref,
+        source_institution_id=inst,
+        pinned_by="tester",
+        write_history_copy=False,
+    )
+    current = Path(rp.genai_reference_current_root(ref, catalog=catalog))
+    (current / "manifest_map.json").write_text('{"m": "tampered"}', encoding="utf-8")
+    with pytest.raises(ValueError, match="hash mismatch"):
+        rp.verify_reference_pin_hash(current)
+
+
+def test_pin_from_onboard_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    catalog = "dev_cat"
+    inst = "demo_col"
+    ref = "ref_demo_03"
+    run_id = "demo_20260102_1"
+    volumes = tmp_path / "Volumes"
+    monkeypatch.setattr(
+        rp,
+        "silver_genai_mapping_root",
+        lambda institution_id, *, catalog: str(
+            volumes
+            / catalog
+            / f"{institution_id}_silver"
+            / "silver_volume"
+            / "genai_mapping"
+        ),
+    )
+    monkeypatch.setattr(
+        rp,
+        "genai_reference_current_root",
+        lambda reference_id, *, catalog: str(
+            volumes
+            / catalog
+            / "genai_mapping"
+            / "references"
+            / reference_id
+            / "current"
+        ),
+    )
+    genai = volumes / catalog / f"{inst}_silver" / "silver_volume" / "genai_mapping"
+    ia = genai / "runs" / "onboard" / run_id / "identity_agent"
+    sma = genai / "runs" / "onboard" / run_id / "schema_mapping_agent"
+    ia.mkdir(parents=True)
+    sma.mkdir(parents=True)
+    (sma / "manifest_map.json").write_text('{"m": 9}', encoding="utf-8")
+    (sma / "transformation_map.json").write_text('{"t": 9}', encoding="utf-8")
+    (ia / "enriched_schema_contract.json").write_text('{"c": 9}', encoding="utf-8")
+
+    pin = rp.pin_reference_snapshot(
+        catalog=catalog,
+        reference_id=ref,
+        source_institution_id=inst,
+        pinned_by="tester",
+        source="onboard_run",
+        onboard_run_id=run_id,
+        pipeline_version="deadbeef",
+        write_history_copy=False,
+    )
+    assert pin["source_onboard_run_id"] == run_id
+    assert pin["pipeline_version"] == "deadbeef"
+    current = Path(rp.genai_reference_current_root(ref, catalog=catalog))
+    assert (current / "manifest_map.json").read_text(encoding="utf-8") == '{"m": 9}'
+
+
+def test_upsert_reference_pin_row_sql(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeSpark:
+        def __init__(self) -> None:
+            self.statements: list[str] = []
+
+        def sql(self, q: str) -> None:
+            self.statements.append(q)
+
+    fake = _FakeSpark()
+    monkeypatch.setattr(
+        "edvise.genai.mapping.state.table_setup.create_state_tables",
+        lambda catalog, spark=None: None,
+    )
+    pin = {
+        "reference_id": "ref_x",
+        "content_hash": "sha256:abc",
+        "pinned_by": "alice",
+        "pinned_at": "2026-06-22T12:00:00Z",
+        "source_institution_id": "school_a",
+        "source_onboard_run_id": "run_1",
+        "pipeline_version": "v1",
+        "archetype": "cc",
+        "artifacts": ["manifest_map.json", "transformation_map.json"],
+    }
+    rp.upsert_reference_pin_row("my_cat", pin, spark=fake)
+    assert any("UPDATE" in s and "superseded" in s for s in fake.statements)
+    insert = next(s for s in fake.statements if "INSERT INTO" in s)
+    assert "reference_pins" in insert
+    assert "ref_x" in insert
+    assert "sha256:abc" in insert
+    assert "active" in insert

--- a/tests/genai/mapping/state/test_pipeline_state.py
+++ b/tests/genai/mapping/state/test_pipeline_state.py
@@ -206,6 +206,8 @@ def test_table_setup_runs_ddl(monkeypatch) -> None:
         == 3
     )
     assert any("hitl_reviews" in s for s in fake.statements)
+    assert any("reference_pins" in s for s in fake.statements)
+    assert any("CREATE VOLUME" in s and "references" in s for s in fake.statements)
 
 
 def test_resolve_onboard_run_id_explicit_override(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Adds shared UC paths under `/Volumes/<catalog>/genai_mapping/references/<reference_id>/current/` (platform volume next to state tables, not school silver).
- Adds `{catalog}.genai_mapping.reference_pins` Delta table + best-effort `CREATE VOLUME` for `genai_mapping.references`.
- Adds `pin_reference_snapshot` / hash verify helpers and admin job `edvise_genai_mapping_pin_reference` to copy from school `active/` (or an onboard run) into the shared library with `genai_reference_pin.json`.

SMA still reads few-shot from school `active/` — this PR only enables pinning. Follow-up: retarget `resolve_reference_sma_active_paths` + hash check on load.

## Asana
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216920327381745?focus=true

## Test plan
- [x] `uv run python -m pytest tests/genai/mapping/shared/test_reference_pin.py tests/genai/mapping/state/test_pipeline_state.py::test_table_setup_runs_ddl -v`
- [ ] Deploy genai_mapping bundle to dev; confirm job `edvise_genai_mapping_pin_reference` appears
- [ ] After a gold school HITL+promote: run pin with `reference_id`, `source_institution_id`, `pinned_by`; confirm files under `…/references/<id>/current/` and a row in `reference_pins`
- [ ] Re-pin same `reference_id`: prior row `status=superseded`, new row `active`, history folder under `references/<id>/`


Made with [Cursor](https://cursor.com)