### PR TITLE
fix(genai): record onboard reference_id on pipeline_runs

### DIFF
--- a/src/edvise/genai/mapping/scripts/edvise_genai_sma.py
+++ b/src/edvise/genai/mapping/scripts/edvise_genai_sma.py
@@ -225,6 +225,31 @@ def resolve_reference_sma_active_paths(
     )
 
 
+def compute_reference_few_shot_content_hash(
+    manifest_path: Path, transformation_map_path: Path
+) -> str | None:
+    """
+    Stable sha256 over the few-shot JSON files SMA will load, or None if either is missing.
+
+    Format ``sha256:<hex>``; same mixing order as reference pin hashes when both files exist.
+    """
+    import hashlib
+
+    items = (
+        ("manifest_map.json", Path(manifest_path)),
+        ("transformation_map.json", Path(transformation_map_path)),
+    )
+    if not all(p.is_file() for _, p in items):
+        return None
+    h = hashlib.sha256()
+    for name, path in items:
+        h.update(name.encode("utf-8"))
+        h.update(b"\0")
+        h.update(path.read_bytes())
+        h.update(b"\0")
+    return f"sha256:{h.hexdigest()}"
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -1497,12 +1522,20 @@ def run(
             )
 
         onboard_run_id_s = cast(str, onboard_run_id)
+        ref_manifest_path, ref_tm_path = resolve_reference_sma_active_paths(
+            reference_id, catalog=catalog
+        )
+        reference_content_hash = compute_reference_few_shot_content_hash(
+            ref_manifest_path, ref_tm_path
+        )
         _pipeline_job_state.on_sma_onboard_begin(
             catalog,
             onboard_run_id_s,
             resume_from=resume_from,
             institution_id=institution_id,
             input_file_paths_json=input_file_paths_json,
+            reference_id=reference_id,
+            reference_content_hash=reference_content_hash,
         )
 
         client = _build_openai_client(catalog)

--- a/src/edvise/genai/mapping/state/__init__.py
+++ b/src/edvise/genai/mapping/state/__init__.py
@@ -23,6 +23,7 @@ from edvise.genai.mapping.state.pipeline_state import (
     update_execute_pipeline_run_input_file_paths,
     update_execute_pipeline_run_status,
     update_onboard_pipeline_run_input_file_paths,
+    update_onboard_pipeline_run_reference,
     update_pipeline_run_status,
 )
 from edvise.genai.mapping.state.table_setup import create_state_tables
@@ -49,5 +50,6 @@ __all__ = [
     "update_execute_pipeline_run_input_file_paths",
     "update_execute_pipeline_run_status",
     "update_onboard_pipeline_run_input_file_paths",
+    "update_onboard_pipeline_run_reference",
     "update_pipeline_run_status",
 ]

--- a/src/edvise/genai/mapping/state/job_state.py
+++ b/src/edvise/genai/mapping/state/job_state.py
@@ -902,6 +902,8 @@ def on_sma_onboard_begin(
     resume_from: str,
     institution_id: str | None = None,
     input_file_paths_json: str | None = None,
+    reference_id: str | None = None,
+    reference_content_hash: str | None = None,
 ) -> None:
     if resume_from == "start":
         _state_safe(
@@ -933,6 +935,20 @@ def on_sma_onboard_begin(
             str(institution_id).strip(),
             onboard_run_id,
             str(input_file_paths_json).strip(),
+        )
+    if (institution_id or "").strip() and (reference_id or "").strip():
+        _state_safe(
+            "pipeline_runs reference_id (SMA onboard)",
+            pipeline_state.update_onboard_pipeline_run_reference,
+            catalog,
+            str(institution_id).strip(),
+            onboard_run_id,
+            reference_id=str(reference_id).strip(),
+            reference_content_hash=(
+                str(reference_content_hash).strip()
+                if (reference_content_hash or "").strip()
+                else None
+            ),
         )
 
 

--- a/src/edvise/genai/mapping/state/pipeline_state.py
+++ b/src/edvise/genai/mapping/state/pipeline_state.py
@@ -3,7 +3,8 @@ Unity Catalog / Delta state for the GenAI mapping pipeline (infrastructure only)
 
 State tables: ``{catalog}.genai_mapping.pipeline_runs`` (``onboard_run_id`` for onboard runs;
 ``execute_run_id`` + ``onboard_run_id`` = artifact source for execute runs; ``db_run_id`` for
-Databricks job correlation), ``pipeline_phases``, ``hitl_reviews``.
+Databricks job correlation; ``reference_id`` / ``reference_content_hash`` for the few-shot
+reference used during SMA onboard), ``pipeline_phases``, ``hitl_reviews``.
 All DML uses :meth:`pyspark.sql.SparkSession.sql` (no Delta Python API, no pandas).
 """
 
@@ -275,6 +276,47 @@ def update_onboard_pipeline_run_input_file_paths(
     UPDATE {t}
     SET
       input_file_paths = {_sql_input_file_paths(raw)},
+      updated_at = current_timestamp()
+    WHERE institution_id = {lit(inst)}
+      AND onboard_run_id = {lit(rid)}
+      AND `catalog` = {lit(c)}
+      AND execute_run_id IS NULL
+    """
+    _spark().sql(q)
+
+
+def update_onboard_pipeline_run_reference(
+    catalog: str,
+    institution_id: str,
+    onboard_run_id: str,
+    *,
+    reference_id: str,
+    reference_content_hash: str | None = None,
+) -> None:
+    """
+    Record which few-shot ``reference_id`` (and optional content hash) SMA used for this onboard.
+
+    Ensures ``pipeline_runs`` has the ``reference_id`` / ``reference_content_hash`` columns
+    (idempotent DDL via :func:`create_state_tables`).
+    """
+    c = str(catalog).strip()
+    inst = str(institution_id).strip()
+    rid = str(onboard_run_id).strip()
+    ref = str(reference_id).strip()
+    if not inst or not rid or not ref:
+        raise ValueError(
+            "institution_id, onboard_run_id, and reference_id must be non-empty"
+        )
+
+    create_state_tables(c, spark=_spark())
+    t = qualified_table(c, PIPELINE_RUNS)
+    href = str(reference_content_hash or "").strip()
+    hash_sql = lit(href) if href else "NULL"
+    q = f"""
+    UPDATE {t}
+    SET
+      reference_id = {lit(ref)},
+      reference_content_hash = {hash_sql},
       updated_at = current_timestamp()
     WHERE institution_id = {lit(inst)}
       AND onboard_run_id = {lit(rid)}

--- a/src/edvise/genai/mapping/state/table_setup.py
+++ b/src/edvise/genai/mapping/state/table_setup.py
@@ -174,6 +174,8 @@ def create_state_tables(catalog: str, spark: Any | None = None) -> None:
           db_run_id STRING,
           execute_run_id STRING,
           input_file_paths STRING,
+          reference_id STRING,
+          reference_content_hash STRING,
           created_at TIMESTAMP,
           updated_at TIMESTAMP
         ) USING DELTA
@@ -184,6 +186,8 @@ def create_state_tables(catalog: str, spark: Any | None = None) -> None:
         ("db_run_id", "STRING"),
         ("execute_run_id", "STRING"),
         ("input_file_paths", "STRING"),
+        ("reference_id", "STRING"),
+        ("reference_content_hash", "STRING"),
     ):
         _add_column_if_missing(spark, pr, _col, _typ)
     spark.sql(

--- a/tests/genai/mapping/state/test_pipeline_state.py
+++ b/tests/genai/mapping/state/test_pipeline_state.py
@@ -198,6 +198,10 @@ def test_table_setup_runs_ddl(monkeypatch) -> None:
     assert any("ALTER TABLE" in s and "db_run_id" in s for s in fake.statements)
     assert any("ALTER TABLE" in s and "execute_run_id" in s for s in fake.statements)
     assert any("ALTER TABLE" in s and "input_file_paths" in s for s in fake.statements)
+    assert any("ALTER TABLE" in s and "reference_id" in s for s in fake.statements)
+    assert any(
+        "ALTER TABLE" in s and "reference_content_hash" in s for s in fake.statements
+    )
     assert (
         sum(
             "RENAME COLUMN pipeline_run_id TO onboard_run_id" in s
@@ -206,6 +210,25 @@ def test_table_setup_runs_ddl(monkeypatch) -> None:
         == 3
     )
     assert any("hitl_reviews" in s for s in fake.statements)
+
+
+def test_update_onboard_pipeline_run_reference(monkeypatch) -> None:
+    fake = _FakeSpark()
+    monkeypatch.setattr(pipeline_state, "get_spark_session", lambda: fake)
+    monkeypatch.setattr(pipeline_state, "create_state_tables", lambda *a, **k: None)
+    pipeline_state.update_onboard_pipeline_run_reference(
+        "c1",
+        "inst1",
+        "run1",
+        reference_id="ref_school",
+        reference_content_hash="sha256:abc",
+    )
+    q = fake.statements[-1]
+    assert "UPDATE" in q
+    assert "reference_id" in q
+    assert "ref_school" in q
+    assert "sha256:abc" in q
+    assert "execute_run_id IS NULL" in q
 
 
 def test_resolve_onboard_run_id_explicit_override(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Adds `reference_id` and `reference_content_hash` columns on `{catalog}.genai_mapping.pipeline_runs` (CREATE + idempotent ALTER).
- SMA onboard begin stamps both from `--reference_id` and a sha256 of the few-shot `manifest_map.json` + `transformation_map.json` being loaded.
- Written on both `start` and `gate_2` so repairs still capture the reference.

## Test plan
- [x] `uv run python -m pytest tests/genai/mapping/state/test_pipeline_state.py -q`
- [ ] Deploy / run an SMA onboard; confirm `pipeline_runs` row has `reference_id` and `reference_content_hash`
- [ ] Re-run `gate_2` alone; columns remain populated


Made with [Cursor](https://cursor.com)