### PR TITLE
fix: default retention max_academic_year to infer

### DIFF
--- a/configs/pdp_h2o/config-RETENTION_TEMPLATE.toml
+++ b/configs/pdp_h2o/config-RETENTION_TEMPLATE.toml
@@ -49,7 +49,7 @@ exclude_pre_cohort_terms = true
 [preprocessing.target]
 name = "retention"
 type_ = "retention"
-max_academic_year = "2024"
+max_academic_year = "infer"
 
 [modeling.feature_selection]
 incomplete_threshold = 0.2


### PR DESCRIPTION
## Summary
task: 
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1217379479382921

- Change `configs/pdp_h2o/config-RETENTION_TEMPLATE.toml` so `preprocessing.target.max_academic_year` is `"infer"` instead of `"2024"`, matching the retention target default and avoiding a stale hardcoded year for new institution configs.